### PR TITLE
feat(02): verify Android APK is signed before Firebase distribution

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -244,6 +244,27 @@ jobs:
           set -euo pipefail
           ./gradlew assembleRelease --no-daemon
 
+      - name: Verify APK is signed
+        run: |
+          set -euo pipefail
+          APK_PATH="android/app/build/outputs/apk/release/app-release.apk"
+          if [ ! -f "$APK_PATH" ]; then
+            echo "❌ APK not found at $APK_PATH"
+            exit 1
+          fi
+          # Use apksigner from Android SDK build-tools (available on ubuntu-latest via setup-java)
+          APKSIGNER=$(find /usr/local/lib/android/sdk/build-tools -name "apksigner" -type f 2>/dev/null | sort -V | tail -1)
+          if [ -z "$APKSIGNER" ]; then
+            echo "⚠️ apksigner not found via SDK path, trying PATH"
+            APKSIGNER=$(command -v apksigner || true)
+          fi
+          if [ -z "$APKSIGNER" ]; then
+            echo "❌ apksigner not available — cannot verify APK signature"
+            exit 1
+          fi
+          "$APKSIGNER" verify --verbose "$APK_PATH"
+          echo "✅ APK signature verified"
+
       - name: Install Firebase CLI
         run: npm install --global firebase-tools
 


### PR DESCRIPTION
Adds apksigner verify step between assembleRelease and Firebase distribute. Fails build if APK is unsigned.