### PR TITLE
ci(security): fix swift CodeQL build on main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -71,7 +71,20 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
+        if: matrix.language != 'swift'
         uses: github/codeql-action/autobuild@v4
+
+      - name: Build Swift for CodeQL
+        if: matrix.language == 'swift'
+        working-directory: ios/OpenClawConsole
+        run: |
+          xcodebuild build \
+            -scheme OpenClawConsole \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
- keep CodeQL autobuild for JavaScript/TypeScript and Java/Kotlin
- switch Swift CodeQL build step to explicit xcodebuild for iOS simulator
- preserve existing analysis and secrets scan behavior

## Why
Security Pipeline on main is failing in CodeQL Analysis (swift) because default autobuild runs swift build with macOS target assumptions.

## Validation
- pre-commit checks passed locally
- PR checks will validate Security Pipeline end-to-end
