### PR TITLE
fix(distribution): use firebase token auth for internal distribution

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -161,7 +161,7 @@ jobs:
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
-          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON || secrets.GOOGLE_PLAY_JSON_KEY }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
           groups: developers
           testers: ${{ secrets.FIREBASE_INTERNAL_TESTERS || vars.FIREBASE_INTERNAL_TESTERS || 'ig5973700@gmail.com' }}
           file: ${{ steps.apk.outputs.canonical }}


### PR DESCRIPTION
## Summary
- switch Android Firebase App Distribution auth to `FIREBASE_TOKEN`
- remove service-account JSON fallback path that currently returns Firebase 403 in CI

## Evidence
- latest run `22731787417` failed at upload with `HTTP 403, The caller does not have permission`
- `FIREBASE_TOKEN` secret is present in repo secrets

## Goal
- align distribution auth with available token-based credential and unblock internal tester delivery
