### PR TITLE
fix(distribution): harden Firebase internal distribution metadata/auth

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -94,27 +94,87 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || inputs.ref || 'develop' }}
 
+      - name: Fail fast on Android distribution auth inputs
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GOOGLE_SERVICES_JSON:-}" ]; then
+            echo "❌ Missing required secret: GOOGLE_SERVICES_JSON"
+            exit 1
+          fi
+          if [ -z "${ANDROID_KEYSTORE_BASE64:-}" ]; then
+            echo "❌ Missing required secret: ANDROID_KEYSTORE_BASE64"
+            exit 1
+          fi
+          if [ -z "${FIREBASE_SERVICE_ACCOUNT_JSON:-}" ] && [ -z "${GOOGLE_PLAY_JSON_KEY:-}" ] && [ -z "${FIREBASE_TOKEN:-}" ]; then
+            echo "❌ Need one of FIREBASE_SERVICE_ACCOUNT_JSON, GOOGLE_PLAY_JSON_KEY, or FIREBASE_TOKEN for Firebase authentication"
+            exit 1
+          fi
+
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
       - name: Write google-services.json
+        working-directory: android
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
+          set -euo pipefail
           if [ -z "${GOOGLE_SERVICES_JSON:-}" ]; then
             echo "Missing GOOGLE_SERVICES_JSON secret"
             exit 1
           fi
-          mkdir -p android/app
-          echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+          echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+
+      - name: Resolve Firebase app metadata
+        id: firebase
+        working-directory: android
+        env:
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
+        run: |
+          set -euo pipefail
+          APP_ID="$(jq -r '.client[0].client_info.mobilesdk_app_id // empty' app/google-services.json)"
+          PACKAGE_NAME="$(jq -r '.client[0].client_info.android_client_info.package_name // empty' app/google-services.json)"
+          if [ -z "$APP_ID" ] && [ -n "${FIREBASE_ANDROID_APP_ID:-}" ]; then
+            APP_ID="$FIREBASE_ANDROID_APP_ID"
+          fi
+          if [ -z "$APP_ID" ]; then
+            echo "❌ Could not resolve Firebase Android app id. Set FIREBASE_ANDROID_APP_ID or include mobilesdk_app_id in GOOGLE_SERVICES_JSON."
+            exit 1
+          fi
+          if [ -z "$PACKAGE_NAME" ]; then
+            echo "❌ Could not resolve package_name from GOOGLE_SERVICES_JSON."
+            exit 1
+          fi
+          if [ "$PACKAGE_NAME" != "com.openclaw.console" ]; then
+            echo "❌ GOOGLE_SERVICES_JSON package_name mismatch: expected com.openclaw.console, got $PACKAGE_NAME"
+            exit 1
+          fi
+          echo "app_id=$APP_ID" >> "$GITHUB_OUTPUT"
+          echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+          echo "Resolved Firebase app id for package $PACKAGE_NAME"
 
       - name: Decode release keystore
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
+          set -euo pipefail
           if [ -z "${ANDROID_KEYSTORE_BASE64:-}" ]; then
             echo "Missing ANDROID_KEYSTORE_BASE64 secret"
             exit 1
@@ -127,12 +187,15 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew assembleRelease --no-daemon --stacktrace
+        run: |
+          set -euo pipefail
+          ./gradlew assembleRelease --no-daemon --stacktrace
         working-directory: android
 
       - name: Resolve APK path
         id: apk
         run: |
+          set -euo pipefail
           APK_PATH="$(find android/app/build/outputs/apk/release -type f -name '*.apk' | grep -v 'unsigned' | head -n 1 || true)"
           if [ -z "$APK_PATH" ]; then
             APK_PATH="$(find android/app/build/outputs/apk/release -type f -name '*.apk' | head -n 1 || true)"
@@ -150,22 +213,59 @@ jobs:
 
       - name: Verify APK signature
         run: |
+          set -euo pipefail
           APKSIGNER="$(find /usr/local/lib/android/sdk/build-tools -name apksigner -type f | sort -V | tail -n 1)"
           if [ -z "$APKSIGNER" ]; then
-            echo "apksigner not found"
+            APKSIGNER="$(command -v apksigner || true)"
+          fi
+          if [ -z "$APKSIGNER" ]; then
+            echo "❌ apksigner not found"
             exit 1
           fi
           "$APKSIGNER" verify --verbose "${{ steps.apk.outputs.canonical }}"
 
-      - name: Build and Distribute to Firebase
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
-        with:
-          appId: ${{ secrets.FIREBASE_ANDROID_APP_ID }}
-          token: ${{ secrets.FIREBASE_TOKEN }}
-          groups: developers
-          testers: ${{ secrets.FIREBASE_INTERNAL_TESTERS || vars.FIREBASE_INTERNAL_TESTERS || 'ig5973700@gmail.com' }}
-          file: ${{ steps.apk.outputs.canonical }}
-          releaseNotes: "GSD Internal build (${{ github.sha }})"
+      - name: Install Firebase CLI
+        run: npm install --global firebase-tools
+
+      - name: Prepare Firebase auth credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "${FIREBASE_SERVICE_ACCOUNT_JSON:-}" ]; then
+            CREDENTIALS_FILE="${RUNNER_TEMP}/firebase-sa.json"
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$CREDENTIALS_FILE"
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$CREDENTIALS_FILE" >> "$GITHUB_ENV"
+          elif [ -n "${GOOGLE_PLAY_JSON_KEY:-}" ]; then
+            CREDENTIALS_FILE="${RUNNER_TEMP}/gcp-sa.json"
+            printf '%s' "$GOOGLE_PLAY_JSON_KEY" > "$CREDENTIALS_FILE"
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$CREDENTIALS_FILE" >> "$GITHUB_ENV"
+          fi
+
+      - name: Distribute to internal Firebase tester(s)
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          FIREBASE_INTERNAL_TESTERS: ${{ vars.FIREBASE_INTERNAL_TESTERS }}
+          FIREBASE_APP_ID: ${{ steps.firebase.outputs.app_id }}
+        run: |
+          set -euo pipefail
+          TESTERS="${FIREBASE_INTERNAL_TESTERS:-ig5973700@gmail.com}"
+          CMD=(
+            firebase appdistribution:distribute
+            "${{ steps.apk.outputs.canonical }}"
+            --app "$FIREBASE_APP_ID"
+            --testers "$TESTERS"
+            --release-notes "GSD Internal build ($GITHUB_SHA)"
+          )
+          if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+            "${CMD[@]}"
+          elif [ -n "${FIREBASE_TOKEN:-}" ]; then
+            "${CMD[@]}" --token "$FIREBASE_TOKEN"
+          else
+            echo "❌ Missing Firebase auth. Set FIREBASE_SERVICE_ACCOUNT_JSON, GOOGLE_PLAY_JSON_KEY, or FIREBASE_TOKEN."
+            exit 1
+          fi
 
       - name: Upload Android APK artifact
         if: always()


### PR DESCRIPTION
## Summary
- Derive Firebase Android app ID from `google-services.json` (fallback to `FIREBASE_ANDROID_APP_ID`).
- Fail fast if Firebase `package_name` is not `com.openclaw.console`.
- Switch Android internal distribution from deprecated Docker action path to Firebase CLI.
- Prefer service-account auth (`FIREBASE_SERVICE_ACCOUNT_JSON` or `GOOGLE_PLAY_JSON_KEY`) with token fallback.

## Why
`develop` Internal Distribution run `22732295125` failed during Firebase upload with `HTTP Error: 400, Precondition check failed`.
This change removes static app-id drift and validates metadata before upload.

## Verification
- YAML parse check:
  - `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/internal-distribution.yml')"`
- Post-merge: rerun Internal Distribution on `develop` and verify Firebase upload step succeeds.
