### PR TITLE
ci: fix claude-review workflow eval failure on main

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,6 +10,8 @@ jobs:
     if: github.event_name == 'pull_request'
     continue-on-error: true
     runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     permissions:
       contents: read
       pull-requests: write
@@ -20,11 +22,11 @@ jobs:
 
       - name: Claude Code Review
         id: claude_review
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
         continue-on-error: true
         uses: anthropics/claude-code-action@ea5a04005c9fd4deed2ed803c15a64d0e6eb65d0 # v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           allowed_bots: "dependabot[bot],github-actions[bot]"
           prompt: |
             Review this PR for the OpenClaw Work Console app. This is a native mobile + TypeScript monorepo:


### PR DESCRIPTION
## Summary
- avoid direct `secrets.*` usage inside a step `if` expression in `claude-review.yml`
- route secret through job env and gate with `env.ANTHROPIC_API_KEY != ''`
- preserve behavior when key exists while removing workflow-evaluation failures that created no jobs

## Verification
- branch created from latest `origin/main`
- commit: `0de8e44`
