### PR TITLE
release(v1.0.11): unblock firebase internal distribution auth

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -392,15 +392,18 @@ jobs:
           DIST_GROUPS="${FIREBASE_INTERNAL_GROUPS:-}"
           APK_PATH="${{ steps.signed_apk.outputs.apk_path }}"
 
-          AUTH_MODE="service-account"
-          if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] && [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
-            # firebase-tools can implicitly prioritize FIREBASE_TOKEN if present.
-            unset FIREBASE_TOKEN
-          elif [ -n "${FIREBASE_TOKEN:-}" ]; then
+          AUTH_MODE=""
+          if [ -n "${FIREBASE_TOKEN:-}" ]; then
             AUTH_MODE="token"
+          elif [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] && [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+            AUTH_MODE="service-account"
           else
             echo "❌ Missing Firebase auth. Set FIREBASE_SERVICE_ACCOUNT_JSON, GOOGLE_PLAY_JSON_KEY, or FIREBASE_TOKEN."
             exit 1
+          fi
+
+          if [ "$AUTH_MODE" = "service-account" ]; then
+            unset FIREBASE_TOKEN
           fi
 
           TESTERS="$(normalize_csv "$TESTERS")"


### PR DESCRIPTION
## Summary
- change Android Firebase distribution auth selection to prefer `FIREBASE_TOKEN` when present
- keep service-account auth as fallback when token is absent
- retain retry logic (audience-targeted -> upload-only)

## Why
- latest internal distribution run (`22784258414`) failed Android upload with service-account auth HTTP 403 (`caller does not have permission`)
- token auth has historically succeeded in this repo and is now the safer default path until service-account IAM is corrected

## Validation
- YAML parse passed for `.github/workflows/internal-distribution.yml`
