### PR TITLE
release(v1.0.12): unblock TestFlight lane on signing mutation crash

### DIFF
--- a/ios/OpenClawConsole/fastlane/Fastfile
+++ b/ios/OpenClawConsole/fastlane/Fastfile
@@ -98,12 +98,16 @@ platform :ios do
     )
 
     if ENV["APPLE_TEAM_ID"] && !ENV["APPLE_TEAM_ID"].empty?
-      update_code_signing_settings(
-        path: "OpenClawConsole.xcodeproj",
-        use_automatic_signing: true,
-        targets: ["OpenClawConsole"],
-        team_id: ENV["APPLE_TEAM_ID"]
-      )
+      begin
+        update_code_signing_settings(
+          path: "OpenClawConsole.xcodeproj",
+          use_automatic_signing: true,
+          targets: ["OpenClawConsole"],
+          team_id: ENV["APPLE_TEAM_ID"]
+        )
+      rescue => e
+        UI.important("Skipping automatic-signing project mutation: #{e}")
+      end
     end
 
     if ENV["CI"] == "true" && ENV["MATCH_GIT_URL"]
@@ -114,18 +118,26 @@ platform :ios do
 
         app_profile = ENV["sigh_com.openclaw.console_appstore_profile-name"] || "match AppStore com.openclaw.console"
 
-        update_code_signing_settings(
-          path: "OpenClawConsole.xcodeproj",
-          use_automatic_signing: false,
-          targets: ["OpenClawConsole"],
-          code_sign_identity: "Apple Distribution",
-          profile_name: app_profile,
-          team_id: ENV["APPLE_TEAM_ID"]
-        )
+        begin
+          update_code_signing_settings(
+            path: "OpenClawConsole.xcodeproj",
+            use_automatic_signing: false,
+            targets: ["OpenClawConsole"],
+            code_sign_identity: "Apple Distribution",
+            profile_name: app_profile,
+            team_id: ENV["APPLE_TEAM_ID"]
+          )
+        rescue => e
+          UI.important("Skipping manual-signing project mutation: #{e}")
+        end
 
         build_app(
           scheme: "OpenClawConsole",
           export_method: "app-store",
+          xcargs: [
+            ("DEVELOPMENT_TEAM=#{ENV['APPLE_TEAM_ID']}" if ENV["APPLE_TEAM_ID"] && !ENV["APPLE_TEAM_ID"].empty?),
+            "-allowProvisioningUpdates"
+          ].compact.join(" "),
           export_options: {
             signingStyle: "manual",
             provisioningProfiles: {
@@ -141,7 +153,10 @@ platform :ios do
         build_app(
           scheme: "OpenClawConsole",
           export_method: "app-store",
-          xcargs: "-allowProvisioningUpdates"
+          xcargs: [
+            ("DEVELOPMENT_TEAM=#{ENV['APPLE_TEAM_ID']}" if ENV["APPLE_TEAM_ID"] && !ENV["APPLE_TEAM_ID"].empty?),
+            "-allowProvisioningUpdates"
+          ].compact.join(" ")
         )
       end
     else
@@ -149,7 +164,10 @@ platform :ios do
       build_app(
         scheme: "OpenClawConsole",
         export_method: "app-store",
-        xcargs: "-allowProvisioningUpdates"
+        xcargs: [
+          ("DEVELOPMENT_TEAM=#{ENV['APPLE_TEAM_ID']}" if ENV["APPLE_TEAM_ID"] && !ENV["APPLE_TEAM_ID"].empty?),
+          "-allowProvisioningUpdates"
+        ].compact.join(" ")
       )
     end
 


### PR DESCRIPTION
## Summary
- make `update_code_signing_settings` non-fatal in `ios beta` lane
- continue builds when Fastlane cannot mutate generated Xcode project format
- pass `DEVELOPMENT_TEAM` via `xcargs` for archive/export paths

## Root Cause
`Internal Distribution` iOS TestFlight failed in `fastlane beta` at:
`update_code_signing_settings` with `Seems to be a very old project file format`.

## Evidence
- failing run: `22785619555`
- failing step: `Build and upload to TestFlight`
- failing action in lane context: `update_code_signing_settings`

## Local verification
- `ruby -c ios/OpenClawConsole/fastlane/Fastfile`
- `xcodebuild -project ios/OpenClawConsole/OpenClawConsole.xcodeproj -scheme OpenClawConsole -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' build`
- `cd android && ./gradlew assembleDebug testDebugUnitTest --no-daemon`
- `cd openclaw-skills && npm test`
