### PR TITLE
release(v1.0.13): fix TestFlight CI signing without Apple account

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -127,7 +127,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.appstoreconnect/private_keys
-          echo "$APPSTORE_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
+          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8"
+          printf '%s' "$APPSTORE_PRIVATE_KEY" > "$KEY_PATH"
+          echo "APPSTORE_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Configure git credentials for match
         env:
@@ -142,6 +144,7 @@ jobs:
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_KEY_PATH: ${{ env.APPSTORE_KEY_PATH }}
           ITC_TEAM_ID: ${{ secrets.ITC_TEAM_ID }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -102,7 +102,9 @@ jobs:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
         run: |
           mkdir -p ~/.appstoreconnect/private_keys
-          echo "$APPSTORE_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8
+          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8"
+          printf '%s' "$APPSTORE_PRIVATE_KEY" > "$KEY_PATH"
+          echo "APPSTORE_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Configure git credentials for match
         env:
@@ -116,6 +118,7 @@ jobs:
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_KEY_PATH: ${{ env.APPSTORE_KEY_PATH }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}

--- a/ios/OpenClawConsole/fastlane/Fastfile
+++ b/ios/OpenClawConsole/fastlane/Fastfile
@@ -1,3 +1,5 @@
+require "shellwords"
+
 default_platform(:ios)
 
 def ensure_xcode_project!
@@ -37,6 +39,39 @@ def app_store_api_key_from_env
     key_content: key_content,
     is_key_content_base64: is_base64
   )
+end
+
+def resolved_appstore_key_path
+  key_id = ENV["APPSTORE_KEY_ID"]
+  return nil if key_id.to_s.empty?
+
+  explicit_key_path = ENV["APPSTORE_KEY_PATH"]
+  return explicit_key_path unless explicit_key_path.to_s.empty?
+
+  File.expand_path("~/.appstoreconnect/private_keys/AuthKey_#{key_id}.p8")
+end
+
+def signing_xcargs
+  args = []
+  args << "DEVELOPMENT_TEAM=#{ENV['APPLE_TEAM_ID']}" unless ENV["APPLE_TEAM_ID"].to_s.empty?
+  args << "-allowProvisioningUpdates"
+
+  key_path = resolved_appstore_key_path
+  has_api_key_auth = (
+    ENV["CI"] == "true" &&
+    !ENV["APPSTORE_KEY_ID"].to_s.empty? &&
+    !ENV["APPSTORE_ISSUER_ID"].to_s.empty? &&
+    !key_path.to_s.empty? &&
+    File.exist?(key_path)
+  )
+
+  if has_api_key_auth
+    args << "-authenticationKeyPath #{Shellwords.escape(key_path)}"
+    args << "-authenticationKeyID #{ENV['APPSTORE_KEY_ID']}"
+    args << "-authenticationKeyIssuerID #{ENV['APPSTORE_ISSUER_ID']}"
+  end
+
+  args.join(" ")
 end
 
 def sync_match_with_bootstrap(api_key:, readonly:)
@@ -134,10 +169,7 @@ platform :ios do
         build_app(
           scheme: "OpenClawConsole",
           export_method: "app-store",
-          xcargs: [
-            ("DEVELOPMENT_TEAM=#{ENV['APPLE_TEAM_ID']}" if ENV["APPLE_TEAM_ID"] && !ENV["APPLE_TEAM_ID"].empty?),
-            "-allowProvisioningUpdates"
-          ].compact.join(" "),
+          xcargs: signing_xcargs,
           export_options: {
             signingStyle: "manual",
             provisioningProfiles: {
@@ -153,10 +185,7 @@ platform :ios do
         build_app(
           scheme: "OpenClawConsole",
           export_method: "app-store",
-          xcargs: [
-            ("DEVELOPMENT_TEAM=#{ENV['APPLE_TEAM_ID']}" if ENV["APPLE_TEAM_ID"] && !ENV["APPLE_TEAM_ID"].empty?),
-            "-allowProvisioningUpdates"
-          ].compact.join(" ")
+          xcargs: signing_xcargs
         )
       end
     else
@@ -164,10 +193,7 @@ platform :ios do
       build_app(
         scheme: "OpenClawConsole",
         export_method: "app-store",
-        xcargs: [
-          ("DEVELOPMENT_TEAM=#{ENV['APPLE_TEAM_ID']}" if ENV["APPLE_TEAM_ID"] && !ENV["APPLE_TEAM_ID"].empty?),
-          "-allowProvisioningUpdates"
-        ].compact.join(" ")
+        xcargs: signing_xcargs
       )
     end
 


### PR DESCRIPTION
## Summary
- add Fastlane helper to inject xcodebuild App Store Connect API-key auth flags in CI
- export `APPSTORE_KEY_PATH` into workflow environment after writing `.p8`
- pass `APPSTORE_KEY_PATH` to TestFlight build/upload steps in internal and native release workflows

## Root Cause
Internal distribution run `22786131403` failed iOS archive with:
- `No Accounts: Add a new account in Accounts settings`
- `No profiles for 'com.openclaw.console' were found`

This happened after match certificate-cap fallback, where automatic provisioning still required credentials on CI runner.

## Verification
- `ruby -c ios/OpenClawConsole/fastlane/Fastfile`
- `cd android && ./gradlew assembleDebug testDebugUnitTest --no-daemon`
- `cd openclaw-skills && npm test`
