### PR TITLE
chore: sync checked-in GitHub config with live policy

### DIFF
--- a/.github/branch-protection.yml
+++ b/.github/branch-protection.yml
@@ -6,17 +6,25 @@ main:
     strict: true
     contexts:
       - "Skills Tests"
-      - "Architecture Lint Kotlin"
-      - "Architecture Lint Swift"
+      - "Architecture Lint (Kotlin)"
+      - "Architecture Lint (Swift)"
       - "Android Build Check"
       - "iOS Build Check"
       - "Secrets Scan"
+      - "Dependency Audit"
+      - "CodeQL Analysis (java-kotlin)"
+      - "CodeQL Analysis (javascript-typescript)"
+      - "CodeQL Analysis (swift)"
+      - "Require develop or release branch"
+      - "Claude Review"
   enforce_admins: true
   required_pull_request_reviews:
     dismissal_restrictions: {}
     dismiss_stale_reviews: true
     require_code_owner_reviews: false
     required_approving_review_count: 0
+    require_last_push_approval: false
+  required_conversation_resolution: false
   restrictions: null
   allow_force_pushes: false
   allow_deletions: false
@@ -26,10 +34,13 @@ develop:
     strict: true
     contexts:
       - "Skills Tests"
-      - "Architecture Lint Kotlin"
-      - "Architecture Lint Swift"
+      - "Architecture Lint (Kotlin)"
+      - "Architecture Lint (Swift)"
   enforce_admins: true
   required_pull_request_reviews:
     dismiss_stale_reviews: true
+    require_code_owner_reviews: false
     required_approving_review_count: 0
+    require_last_push_approval: false
+  required_conversation_resolution: false
   restrictions: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -8,7 +8,7 @@ repository:
   has_projects: true
   has_wiki: true
   has_downloads: true
-  default_branch: develop
+  default_branch: main
   allow_squash_merge: true
   allow_merge_commit: false
   allow_rebase_merge: false
@@ -21,26 +21,28 @@ branches:
     protection:
       required_status_checks:
         strict: true
-        # Production mirror - only accepts release/hotfix merges
+        # Production mirror - only accepts trusted Dependabot, develop, release/*, or hotfix/* merges
         contexts:
           - "Skills Tests"
-          - "Architecture Lint Kotlin"
-          - "Architecture Lint Swift"
+          - "Architecture Lint (Kotlin)"
+          - "Architecture Lint (Swift)"
           - "Android Build Check"
           - "iOS Build Check"
           - "Secrets Scan"
+          - "Dependency Audit"
+          - "CodeQL Analysis (java-kotlin)"
+          - "CodeQL Analysis (javascript-typescript)"
+          - "CodeQL Analysis (swift)"
+          - "Require develop or release branch"
+          - "Claude Review"
       enforce_admins: true
       required_pull_request_reviews:
-        required_approving_review_count: 1
+        required_approving_review_count: 0
         dismiss_stale_reviews: true
-        require_code_owner_reviews: true
+        require_code_owner_reviews: false
         require_last_push_approval: false
-      required_conversation_resolution: true
-      restrictions:
-        # Only release and hotfix branches can merge to main
-        users: []
-        teams: []
-        apps: []
+      required_conversation_resolution: false
+      restrictions: null
       allow_force_pushes: false
       allow_deletions: false
 
@@ -51,18 +53,15 @@ branches:
         # Integration branch - all feature work merges here first
         contexts:
           - "Skills Tests"
-          - "Architecture Lint Kotlin"
-          - "Architecture Lint Swift"
-          - "Android Build Check"
-          - "iOS Build Check"
-          - "Secrets Scan"
+          - "Architecture Lint (Kotlin)"
+          - "Architecture Lint (Swift)"
       enforce_admins: true
       required_pull_request_reviews:
         required_approving_review_count: 0
         dismiss_stale_reviews: true
         require_code_owner_reviews: false
         require_last_push_approval: false
-      required_conversation_resolution: true
+      required_conversation_resolution: false
       restrictions: null
       allow_force_pushes: false
       allow_deletions: false


### PR DESCRIPTION
## What
Sync checked-in GitHub configuration snapshots to the live repo policy already running on GitHub.

## Why
An audit on March 10, 2026 found `.github/settings.yml` and `.github/branch-protection.yml` were stale and would reintroduce drift if applied.

## Changes
- set `default_branch: main`
- update required check names to the live contexts
- add the missing main-branch required checks
- align review and conversation-resolution settings with the live branch protection
- keep `develop` protection contexts aligned with the live repo

## Verification
- parsed both YAML files successfully
- compared checked-in values against `gh api` readback for repo settings and branch protection
- no product code changed
