### PR TITLE
fix: recover Dependabot automerge checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -24,7 +25,7 @@ jobs:
       - name: Architecture ban checks
         run: |
           ERRORS=0
-          for f in $(find android -name '*.kt' -not -path '*/build/*'); do
+          while IFS= read -r f; do
             if grep -n 'AndroidViewModel' "$f" | grep -v '// allow-android-viewmodel' > /dev/null 2>&1; then
               echo ":: $f: Uses AndroidViewModel (use ViewModel instead)"
               ERRORS=$((ERRORS + 1))
@@ -37,7 +38,7 @@ jobs:
               echo ":: $f: Uses !! non-null assertion without justification"
               ERRORS=$((ERRORS + 1))
             fi
-          done
+          done < <(find android -name '*.kt' -not -path '*/build/*')
           if [ "$ERRORS" -gt 0 ]; then
             echo "Found $ERRORS architecture violation(s)"
             exit 1
@@ -53,7 +54,7 @@ jobs:
       - name: Architecture ban checks
         run: |
           ERRORS=0
-          for f in $(find ios -name '*.swift'); do
+          while IFS= read -r f; do
             if grep -n 'force_cast\|as!' "$f" | grep -v '// allow-force-cast' > /dev/null 2>&1; then
               echo ":: $f: Uses force cast (as!) without justification"
               ERRORS=$((ERRORS + 1))
@@ -62,7 +63,7 @@ jobs:
               echo ":: $f: Uses plain HTTP URL (use HTTPS)"
               ERRORS=$((ERRORS + 1))
             fi
-          done
+          done < <(find ios -name '*.swift')
           if [ "$ERRORS" -gt 0 ]; then
             echo "Found $ERRORS architecture violation(s)"
             exit 1

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,6 +15,7 @@ on:
         required: false
 
 permissions:
+  actions: write
   contents: write
   checks: read
   statuses: read
@@ -35,6 +36,9 @@ jobs:
         uses: actions/github-script@v8
         env:
           TARGET_PR_NUMBER: ${{ github.event.inputs.pr_number || '' }}
+          REQUIRED_CHECKS_DEVELOP: ${{ vars.PR_REQUIRED_CHECKS_DEVELOP || '' }}
+          REQUIRED_CHECKS_MAIN: ${{ vars.PR_REQUIRED_CHECKS_MAIN || '' }}
+          REQUIRED_CHECKS_FROM_VAR: ${{ vars.PR_REQUIRED_CHECKS || '' }}
         with:
           script: |
             const owner = context.repo.owner;
@@ -45,6 +49,23 @@ jobs:
             const FAILING_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required", "startup_failure", "stale"]);
             const FAILING_STATES = new Set(["error", "failure"]);
             const PENDING_STATES = new Set(["pending"]);
+            const DEFAULT_REQUIRED_CHECKS = {
+              develop: ["Skills Tests", "Architecture Lint (Kotlin)", "Architecture Lint (Swift)"],
+              main: [
+                "Skills Tests",
+                "Architecture Lint (Kotlin)",
+                "Architecture Lint (Swift)",
+                "Android Build Check",
+                "iOS Build Check",
+                "Secrets Scan",
+                "Dependency Audit",
+                "CodeQL Analysis (java-kotlin)",
+                "CodeQL Analysis (javascript-typescript)",
+                "CodeQL Analysis (swift)",
+                "Require develop or release branch",
+                "Claude Review"
+              ]
+            };
 
             function labelNames(pr) {
               return (pr.labels || []).map((label) => label.name);
@@ -52,6 +73,34 @@ jobs:
 
             function isDependabotPr(pr) {
               return DEPENDABOT_LOGINS.has(pr.user?.login || "") && (pr.head?.ref || "").startsWith("dependabot/");
+            }
+
+            function parseRequiredChecks(raw) {
+              return raw
+                .split(",")
+                .map((value) => value.trim())
+                .filter((value) => value.length > 0);
+            }
+
+            function requiredContextsFromFallback(baseBranch) {
+              const normalized = baseBranch.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+              const branchEnvName = `REQUIRED_CHECKS_${normalized}`;
+              const fromBranchVar = parseRequiredChecks(process.env[branchEnvName] || "");
+              if (fromBranchVar.length > 0) {
+                return { contexts: fromBranchVar, source: `vars.PR_REQUIRED_CHECKS_${normalized}` };
+              }
+
+              const fromWorkflowDefault = DEFAULT_REQUIRED_CHECKS[baseBranch] || [];
+              if (fromWorkflowDefault.length > 0) {
+                return { contexts: fromWorkflowDefault, source: `workflow_default:${baseBranch}` };
+              }
+
+              const fromGenericVar = parseRequiredChecks(process.env.REQUIRED_CHECKS_FROM_VAR || "");
+              if (fromGenericVar.length > 0) {
+                return { contexts: fromGenericVar, source: "vars.PR_REQUIRED_CHECKS" };
+              }
+
+              return { contexts: [], source: "none" };
             }
 
             async function listCandidatePrs() {
@@ -93,11 +142,12 @@ jobs:
                     contexts.add(check.context);
                   }
                 }
-                return [...contexts];
+                return { contexts: [...contexts], source: "branch_protection" };
               } catch (error) {
                 core.warning(`Could not read branch protection for ${baseBranch}: ${error.message}`);
-                return [];
               }
+
+              return requiredContextsFromFallback(baseBranch);
             }
 
             async function getCheckRunMap(headSha) {
@@ -164,13 +214,36 @@ jobs:
               return { outcome: "pending", detail: "missing" };
             }
 
+            async function triggerWorkflow(workflowId, ref) {
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: workflowId,
+                  ref
+                });
+                core.info(`Triggered ${workflowId} for ${ref}.`);
+              } catch (error) {
+                core.warning(`Could not trigger ${workflowId} for ${ref}: ${error.message}`);
+              }
+            }
+
+            async function triggerMissingRequiredChecks(pr, missingRequiredCheckNames) {
+              const ciChecks = new Set(["Skills Tests", "Architecture Lint (Kotlin)", "Architecture Lint (Swift)"]);
+              if (missingRequiredCheckNames.some((name) => ciChecks.has(name))) {
+                await triggerWorkflow("ci.yml", pr.head.ref);
+              }
+            }
+
             async function requiredChecksAreGreen(pr) {
-              const contexts = await requiredContextsFor(pr.base.ref);
+              const required = await requiredContextsFor(pr.base.ref);
+              const contexts = required.contexts;
               if (contexts.length === 0) {
                 core.warning(`PR #${pr.number}: no required checks resolved for ${pr.base.ref}; refusing autonomous merge.`);
                 return false;
               }
 
+              core.info(`PR #${pr.number}: required checks source=${required.source}.`);
               const checkRunMap = await getCheckRunMap(pr.head.sha);
               const statusContextMap = await getStatusContextMap(pr.head.sha);
               const results = contexts.map((name) => ({
@@ -181,6 +254,10 @@ jobs:
               const pending = results.filter((result) => result.outcome === "pending");
 
               if (failed.length > 0 || pending.length > 0) {
+                const missing = pending.filter((result) => result.detail === "missing").map((result) => result.name);
+                if (missing.length > 0) {
+                  await triggerMissingRequiredChecks(pr, missing);
+                }
                 core.info(
                   `PR #${pr.number}: waiting. failed=${failed.map((r) => `${r.name}:${r.detail}`).join(",") || "none"} pending=${pending
                     .map((r) => `${r.name}:${r.detail}`)
@@ -248,6 +325,7 @@ jobs:
                     pull_number: pr.number,
                     expected_head_sha: pr.head.sha
                   });
+                  await triggerWorkflow("ci.yml", pr.head.ref);
                 } catch (error) {
                   core.warning(`PR #${pr.number}: branch update failed: ${error.message}`);
                 }

--- a/.github/workflows/pr-state-machine.yml
+++ b/.github/workflows/pr-state-machine.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   check_suite:
-    types: [requested, rerequested, completed]
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -25,6 +25,8 @@ jobs:
       - name: Reconcile labels, commit status, and incidents
         uses: actions/github-script@v8
         env:
+          REQUIRED_CHECKS_DEVELOP: ${{ vars.PR_REQUIRED_CHECKS_DEVELOP || '' }}
+          REQUIRED_CHECKS_MAIN: ${{ vars.PR_REQUIRED_CHECKS_MAIN || '' }}
           REQUIRED_CHECKS_FROM_VAR: ${{ vars.PR_REQUIRED_CHECKS || '' }}
         with:
           script: |
@@ -46,6 +48,23 @@ jobs:
             const FAILING_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required", "startup_failure", "stale"]);
             const FAILING_STATES = new Set(["error", "failure"]);
             const PENDING_STATES = new Set(["pending"]);
+            const DEFAULT_REQUIRED_CHECKS = {
+              develop: ["Skills Tests", "Architecture Lint (Kotlin)", "Architecture Lint (Swift)"],
+              main: [
+                "Skills Tests",
+                "Architecture Lint (Kotlin)",
+                "Architecture Lint (Swift)",
+                "Android Build Check",
+                "iOS Build Check",
+                "Secrets Scan",
+                "Dependency Audit",
+                "CodeQL Analysis (java-kotlin)",
+                "CodeQL Analysis (javascript-typescript)",
+                "CodeQL Analysis (swift)",
+                "Require develop or release branch",
+                "Claude Review"
+              ]
+            };
 
             function uniqueNumbers(values) {
               return [...new Set(values.filter((v) => Number.isInteger(v) && v > 0))];
@@ -56,6 +75,36 @@ jobs:
                 .split(",")
                 .map((v) => v.trim())
                 .filter((v) => v.length > 0);
+            }
+
+            function getRequiredContextsFallback(baseBranch) {
+              const normalized = baseBranch.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+              const branchEnvName = `REQUIRED_CHECKS_${normalized}`;
+              const branchFallback = parseRequiredChecks(process.env[branchEnvName] || "");
+              if (branchFallback.length > 0) {
+                return {
+                  contexts: branchFallback,
+                  source: `vars.PR_REQUIRED_CHECKS_${normalized}`
+                };
+              }
+
+              const workflowDefault = DEFAULT_REQUIRED_CHECKS[baseBranch] || [];
+              if (workflowDefault.length > 0) {
+                return {
+                  contexts: workflowDefault,
+                  source: `workflow_default:${baseBranch}`
+                };
+              }
+
+              const fallbackFromVar = parseRequiredChecks(process.env.REQUIRED_CHECKS_FROM_VAR || "");
+              if (fallbackFromVar.length > 0) {
+                return {
+                  contexts: fallbackFromVar,
+                  source: "vars.PR_REQUIRED_CHECKS"
+                };
+              }
+
+              return { contexts: [], source: "none" };
             }
 
             async function ensureLabel(name) {
@@ -111,15 +160,7 @@ jobs:
                 core.warning(`Branch protection lookup failed for ${baseBranch}: ${error.message}`);
               }
 
-              const fallbackFromVar = parseRequiredChecks(process.env.REQUIRED_CHECKS_FROM_VAR || "");
-              if (fallbackFromVar.length > 0) {
-                return {
-                  contexts: fallbackFromVar,
-                  source: "vars.PR_REQUIRED_CHECKS"
-                };
-              }
-
-              return { contexts: [], source: "none" };
+              return getRequiredContextsFallback(baseBranch);
             }
 
             async function getCheckRunMap(headSha) {


### PR DESCRIPTION
## What changed

- Make Dependabot automerge and PR state reconciliation use branch-specific required-check fallbacks when the workflow token cannot read branch protection.
- Add built-in `develop` and `main` required-check defaults so the workflows do not fall back to an incorrect global check list.
- Add `workflow_dispatch` to CI and let the Dependabot orchestrator dispatch CI when required CI checks are missing after an automated branch update.
- Remove invalid `check_suite` activity types from the PR state machine workflow.
- Replace fragile `find` command substitution loops in CI with `while read` loops so `actionlint` passes cleanly.

## Root cause

The live Dependabot automerge workflow was running but refusing to act because `GITHUB_TOKEN` could not read branch protection: `Resource not accessible by integration`. Separately, the PR state machine fell back to the global `PR_REQUIRED_CHECKS` list, which contains `main`-only checks, so `develop` PRs could be labeled as still running even when their actual required checks were green.

A second failure mode appeared after branch updates: Actions-authored branch update commits can leave the new head SHA without the required PR CI checks. The orchestrator now has a CI dispatch path for that recovery case.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/dependabot-auto-merge.yml .github/workflows/pr-state-machine.yml`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "parsed #{path}" }' .github/workflows/ci.yml .github/workflows/dependabot-auto-merge.yml .github/workflows/pr-state-machine.yml`
- `git diff --check`

## Live remediation already applied

- PR #200 merged at `2026-04-15T23:08:48Z`.
- PR #198, #201, and #202 were reopened to trigger real PR CI and have squash auto-merge enabled again.
- Repo variables `PR_REQUIRED_CHECKS_DEVELOP` and `PR_REQUIRED_CHECKS_MAIN` were set.
