### PR TITLE
feat: add high-ROI ops runtime controls

### DIFF
--- a/openclaw-skills/src/config/default.ts
+++ b/openclaw-skills/src/config/default.ts
@@ -31,6 +31,16 @@ export interface GatewayConfig {
   mcpServers: string[];
   /** CORS allowed origins ('*' for all) */
   corsOrigins: string;
+  /** Approval automation preset. manual keeps every gate human-driven. */
+  approvalPolicyPreset: 'manual' | 'safe-yolo' | 'repo-yolo' | 'ci-yolo' | 'danger-yolo';
+  /** How frequently WebSocket clients receive heartbeat/status events */
+  heartbeatIntervalMs: number;
+  /** Local OpenAI-compatible model endpoint, e.g. vLLM on Jetson */
+  localModelBaseUrl: string | null;
+  /** Local model identifier to display and use for local chat calls */
+  localModelName: string | null;
+  /** Local model status probe timeout in milliseconds */
+  localModelTimeoutMs: number;
 }
 
 const DEFAULT_CONFIG: GatewayConfig = {
@@ -48,6 +58,18 @@ const DEFAULT_CONFIG: GatewayConfig = {
   simulateBridges: process.env['SIMULATE_BRIDGES'] !== 'false',
   mcpServers: process.env['MCP_SERVERS']?.split(';') ?? [],
   corsOrigins: process.env['CORS_ORIGINS'] ?? '*',
+  approvalPolicyPreset: parseApprovalPolicyPreset(process.env['OPENCLAW_APPROVAL_POLICY'] ?? 'manual'),
+  heartbeatIntervalMs: parseInt(process.env['OPENCLAW_HEARTBEAT_INTERVAL_MS'] ?? '10000', 10),
+  localModelBaseUrl: process.env['OPENCLAW_LOCAL_MODEL_BASE_URL'] ?? process.env['OPENAI_BASE_URL'] ?? null,
+  localModelName: process.env['OPENCLAW_LOCAL_MODEL_NAME'] ?? null,
+  localModelTimeoutMs: parseInt(process.env['OPENCLAW_LOCAL_MODEL_TIMEOUT_MS'] ?? '2500', 10),
 };
+
+function parseApprovalPolicyPreset(raw: string): GatewayConfig['approvalPolicyPreset'] {
+  if (raw === 'safe-yolo' || raw === 'repo-yolo' || raw === 'ci-yolo' || raw === 'danger-yolo') {
+    return raw;
+  }
+  return 'manual';
+}
 
 export default DEFAULT_CONFIG;

--- a/openclaw-skills/src/gateway/model-provider.ts
+++ b/openclaw-skills/src/gateway/model-provider.ts
@@ -1,0 +1,62 @@
+import type { GatewayConfig } from '../config/default.js';
+
+export interface LocalModelProviderStatus {
+  enabled: boolean;
+  base_url: string | null;
+  model: string | null;
+  reachable: boolean;
+  latency_ms: number | null;
+  checked_at: string;
+  error: string | null;
+}
+
+export function getConfiguredLocalModel(config: GatewayConfig): Pick<LocalModelProviderStatus, 'enabled' | 'base_url' | 'model'> {
+  return {
+    enabled: Boolean(config.localModelBaseUrl && config.localModelName),
+    base_url: config.localModelBaseUrl,
+    model: config.localModelName,
+  };
+}
+
+export async function probeLocalModelProvider(
+  config: GatewayConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<LocalModelProviderStatus> {
+  const configured = getConfiguredLocalModel(config);
+  const checkedAt = new Date().toISOString();
+  if (!configured.enabled || !configured.base_url) {
+    return {
+      ...configured,
+      reachable: false,
+      latency_ms: null,
+      checked_at: checkedAt,
+      error: 'local model provider is not configured',
+    };
+  }
+
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.localModelTimeoutMs);
+
+  try {
+    const url = new URL('/v1/models', configured.base_url);
+    const response = await fetchImpl(url, { signal: controller.signal });
+    return {
+      ...configured,
+      reachable: response.ok,
+      latency_ms: Date.now() - startedAt,
+      checked_at: checkedAt,
+      error: response.ok ? null : `HTTP ${response.status}`,
+    };
+  } catch (error) {
+    return {
+      ...configured,
+      reachable: false,
+      latency_ms: Date.now() - startedAt,
+      checked_at: checkedAt,
+      error: error instanceof Error ? error.message : 'unknown local model probe error',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/openclaw-skills/src/gateway/policy.ts
+++ b/openclaw-skills/src/gateway/policy.ts
@@ -1,0 +1,101 @@
+import type { GatewayConfig } from '../config/default.js';
+import type { ActionType, ApprovalContext } from '../types/protocol.js';
+
+export interface ApprovalPolicyDecision {
+  autoApproved: boolean;
+  preset: GatewayConfig['approvalPolicyPreset'];
+  reason: string;
+}
+
+export interface ApprovalPolicyInput {
+  actionType: ActionType;
+  command: string;
+  context: ApprovalContext;
+}
+
+const SAFE_READ_ONLY_COMMANDS = [
+  /^git\s+(status|diff|log|show|branch|remote|rev-parse|ls-files)\b/,
+  /^gh\s+(pr|run|repo|api)\s+(view|list|checks|status)\b/,
+  /^npm\s+(test|run\s+(test|lint|build|typecheck))\b/,
+  /^pnpm\s+(test|exec|run)\b/,
+  /^yarn\s+(test|lint|build)\b/,
+  /^make\s+(test|lint|check)\b/,
+];
+
+const REPO_WRITE_ACTIONS = new Set<ActionType>(['git_commit', 'git_push', 'propose_fix']);
+const CI_ACTIONS = new Set<ActionType>(['ask_root_cause', 'propose_fix', 'acknowledge', 'shell_command']);
+const NEVER_AUTO_APPROVE = new Set<ActionType>(['destructive', 'deploy', 'key_rotation', 'trade_execution']);
+const PROTECTED_BRANCHES = new Set(['main', 'master', 'production', 'prod']);
+
+export function evaluateApprovalPolicy(
+  preset: GatewayConfig['approvalPolicyPreset'],
+  input: ApprovalPolicyInput,
+): ApprovalPolicyDecision {
+  if (preset === 'manual') {
+    return deny(preset, 'manual policy requires explicit approval');
+  }
+
+  if (NEVER_AUTO_APPROVE.has(input.actionType)) {
+    return deny(preset, `${input.actionType} is never auto-approved`);
+  }
+
+  if (input.context.risk_level === 'critical' && preset !== 'danger-yolo') {
+    return deny(preset, 'critical risk requires explicit approval');
+  }
+
+  if (preset === 'safe-yolo') {
+    return isReadOnlyCommand(input.command)
+      ? allow(preset, 'safe-yolo read-only command')
+      : deny(preset, 'safe-yolo only allows read-only commands');
+  }
+
+  if (preset === 'ci-yolo') {
+    if (!CI_ACTIONS.has(input.actionType)) {
+      return deny(preset, `ci-yolo does not allow ${input.actionType}`);
+    }
+    return isReadOnlyCommand(input.command) || isCiCommand(input.command)
+      ? allow(preset, 'ci-yolo allowed CI/read-only command')
+      : deny(preset, 'ci-yolo command is not in the CI allowlist');
+  }
+
+  if (preset === 'repo-yolo') {
+    if (targetsProtectedBranch(input.context)) {
+      return deny(preset, 'protected branch writes require explicit approval');
+    }
+    if (REPO_WRITE_ACTIONS.has(input.actionType) || isReadOnlyCommand(input.command) || isCiCommand(input.command)) {
+      return allow(preset, 'repo-yolo allowed repository operation');
+    }
+    return deny(preset, `repo-yolo does not allow ${input.actionType}`);
+  }
+
+  if (preset === 'danger-yolo') {
+    return allow(preset, 'danger-yolo auto-approved non-destructive action');
+  }
+
+  return deny(preset, 'unknown policy preset');
+}
+
+function allow(preset: GatewayConfig['approvalPolicyPreset'], reason: string): ApprovalPolicyDecision {
+  return { autoApproved: true, preset, reason };
+}
+
+function deny(preset: GatewayConfig['approvalPolicyPreset'], reason: string): ApprovalPolicyDecision {
+  return { autoApproved: false, preset, reason };
+}
+
+function isReadOnlyCommand(command: string): boolean {
+  const normalized = command.trim();
+  return SAFE_READ_ONLY_COMMANDS.some((pattern) => pattern.test(normalized));
+}
+
+function isCiCommand(command: string): boolean {
+  const normalized = command.trim();
+  return /^(npm|pnpm|yarn)\s+(test|run\s+(test|lint|build|typecheck))\b/.test(normalized) ||
+    /^(\.\/gradlew|gradle)\s+.+\b(test|lint|assemble|check)\b/.test(normalized) ||
+    /^xcodebuild\s+.+\b(build|test)\b/.test(normalized);
+}
+
+function targetsProtectedBranch(context: ApprovalContext): boolean {
+  const branch = context.git_operation?.branch_to ?? context.git_operation?.branch_from ?? '';
+  return PROTECTED_BRANCHES.has(branch.toLowerCase());
+}

--- a/openclaw-skills/src/gateway/server.ts
+++ b/openclaw-skills/src/gateway/server.ts
@@ -29,6 +29,7 @@ import { ERROR_CODES } from '../types/protocol.js';
 import { createBillingRouter } from '../billing/revenuecat.js';
 import { createAnalyticsRouter } from '../analytics/events.js';
 import { createIntegrationsRouter } from '../integrations/devops-hub.js';
+import { getConfiguredLocalModel, probeLocalModelProvider } from './model-provider.js';
 
 export interface GatewayServer {
   httpServer: http.Server;
@@ -72,19 +73,50 @@ export function createGatewayServer(
   // ── Health ───────────────────────────────────────────────────────────────
 
   const startedAt = Date.now();
+  const startedAtIso = new Date(startedAt).toISOString();
 
   app.get('/api/health', (_req: Request, res: Response) => {
     const tasks = state.listAllTasks();
+    const wsSnapshot = wsManager.getRuntimeSnapshot();
     const body: HealthResponse = {
       status: 'ok',
       version: config.version,
+      started_at: startedAtIso,
+      checked_at: new Date().toISOString(),
       uptime_seconds: Math.floor((Date.now() - startedAt) / 1000),
       agent_count: state.listAgents().length,
       active_tasks: tasks.filter((t) => t.status === 'running' || t.status === 'queued').length,
       open_incidents: state.listIncidents().filter((i) => i.status === 'open').length,
       pending_approvals: state.listPendingApprovals().length,
+      websocket_clients: wsSnapshot.connected_clients,
+      last_inbound_ws_at: wsSnapshot.last_inbound_at,
+      last_outbound_ws_at: wsSnapshot.last_outbound_at,
+      approval_policy_preset: config.approvalPolicyPreset,
+      local_model: getConfiguredLocalModel(config),
     };
     res.json(body);
+  });
+
+  app.get('/api/runtime/status', auth, (_req: Request, res: Response) => {
+    res.json({
+      checked_at: new Date().toISOString(),
+      gateway: {
+        status: 'ok',
+        version: config.version,
+        started_at: startedAtIso,
+        uptime_seconds: Math.floor((Date.now() - startedAt) / 1000),
+      },
+      websocket: wsManager.getRuntimeSnapshot(),
+      approval_policy: {
+        preset: config.approvalPolicyPreset,
+        require_biometric: config.requireBiometric,
+      },
+      local_model: getConfiguredLocalModel(config),
+    });
+  });
+
+  app.get('/api/model/status', auth, async (_req: Request, res: Response) => {
+    res.json(await probeLocalModelProvider(config));
   });
 
   // ── Agents ───────────────────────────────────────────────────────────────
@@ -308,6 +340,7 @@ export function createGatewayServer(
     },
     stop(): Promise<void> {
       return new Promise((resolve, reject) => {
+        wsManager.stop();
         wss.close();
         httpServer.close((err) => {
           if (err) reject(err);

--- a/openclaw-skills/src/gateway/websocket.ts
+++ b/openclaw-skills/src/gateway/websocket.ts
@@ -17,6 +17,7 @@ import type {
   WsApprovalResponse,
   WsChatMessage,
   ConnectedPayload,
+  GatewayHeartbeatPayload,
   ErrorPayload,
   Agent,
   Task,
@@ -41,6 +42,19 @@ interface ClientSession {
   pingTimer: ReturnType<typeof setInterval>;
   pongDeadline: ReturnType<typeof setTimeout> | null;
   connectedAt: string;
+  lastMessageAt: string | null;
+}
+
+export interface WebSocketRuntimeSnapshot {
+  connected_clients: number;
+  last_inbound_at: string | null;
+  last_outbound_at: string | null;
+  sessions: Array<{
+    id: string;
+    connected_at: string;
+    last_message_at: string | null;
+    subscribed_agents: string[];
+  }>;
 }
 
 // ── WebSocket Manager ─────────────────────────────────────────────────────────
@@ -51,12 +65,19 @@ export class WebSocketManager {
   private clients: Map<string, ClientSession> = new Map();
   private config: GatewayConfig;
   private state: StateManager;
+  private heartbeatTimer: ReturnType<typeof setInterval>;
+  private startedAt = Date.now();
+  private lastInboundAt: string | null = null;
+  private lastOutboundAt: string | null = null;
 
   constructor(wss: WebSocketServer, state: StateManager, config: GatewayConfig) {
     this.wss = wss;
     this.state = state;
     this.config = config;
     this.attachStateListeners();
+    this.heartbeatTimer = setInterval(() => {
+      this.broadcastHeartbeat();
+    }, this.config.heartbeatIntervalMs);
   }
 
   // ── State → Broadcast bridge ─────────────────────────────────────────────
@@ -151,6 +172,7 @@ export class WebSocketManager {
       pingTimer,
       pongDeadline: null,
       connectedAt: new Date().toISOString(),
+      lastMessageAt: null,
     };
     this.clients.set(sessionId, session);
 
@@ -162,6 +184,9 @@ export class WebSocketManager {
     });
 
     ws.on('message', (raw) => {
+      const now = new Date().toISOString();
+      this.lastInboundAt = now;
+      session.lastMessageAt = now;
       this.handleMessage(session, raw.toString());
     });
 
@@ -178,6 +203,7 @@ export class WebSocketManager {
     const connected: ConnectedPayload = {
       session_id: sessionId,
       gateway_version: this.config.version,
+      heartbeat_interval_ms: this.config.heartbeatIntervalMs,
     };
     this.send(session, 'connected', connected);
 
@@ -276,6 +302,7 @@ export class WebSocketManager {
       payload,
       timestamp: new Date().toISOString(),
     };
+    this.lastOutboundAt = envelope.timestamp;
     session.ws.send(JSON.stringify(envelope));
   }
 
@@ -311,9 +338,38 @@ export class WebSocketManager {
     return this.clients.size;
   }
 
+  public getRuntimeSnapshot(): WebSocketRuntimeSnapshot {
+    return {
+      connected_clients: this.clients.size,
+      last_inbound_at: this.lastInboundAt,
+      last_outbound_at: this.lastOutboundAt,
+      sessions: Array.from(this.clients.values()).map((session) => ({
+        id: session.id,
+        connected_at: session.connectedAt,
+        last_message_at: session.lastMessageAt,
+        subscribed_agents: Array.from(session.subscribedAgents),
+      })),
+    };
+  }
+
+  public stop(): void {
+    clearInterval(this.heartbeatTimer);
+  }
+
   /** WebSocketServer instance (for attaching to HTTP server). */
   public get server(): WebSocketServer {
     return this.wss;
+  }
+
+  private broadcastHeartbeat(): void {
+    const payload: GatewayHeartbeatPayload = {
+      gateway_version: this.config.version,
+      connected_clients: this.connectionCount,
+      last_inbound_at: this.lastInboundAt,
+      last_outbound_at: this.lastOutboundAt,
+      uptime_seconds: Math.floor((Date.now() - this.startedAt) / 1000),
+    };
+    this.broadcastToAll('heartbeat', payload);
   }
 }
 

--- a/openclaw-skills/src/skills/approval-gate.ts
+++ b/openclaw-skills/src/skills/approval-gate.ts
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import type { ApprovalRequest, ApprovalResponse, ActionType, RiskLevel, GitOperation } from '../types/protocol.js';
 import type { IStateManager } from '../gateway/state-interface.js';
 import type { GatewayConfig } from '../config/default.js';
+import { evaluateApprovalPolicy } from '../gateway/policy.js';
 
 export interface DangerousActionOptions {
   agentId: string;
@@ -46,6 +47,9 @@ export interface ApprovalLogEntry {
   biometricVerified: boolean;
   requestedAt: string;
   respondedAt: string | null;
+  autoApproved: boolean;
+  policyPreset: GatewayConfig['approvalPolicyPreset'];
+  policyReason: string | null;
 }
 
 /**
@@ -91,6 +95,7 @@ export class ApprovalGateSkill {
         environment: options.context.environment,
         repository: options.context.repository,
         risk_level: options.context.riskLevel,
+        git_operation: options.context.git_operation,
       },
       created_at: now.toISOString(),
       expires_at: expiresAt.toISOString(),
@@ -105,7 +110,35 @@ export class ApprovalGateSkill {
       biometricVerified: false,
       requestedAt: request.created_at,
       respondedAt: null,
+      autoApproved: false,
+      policyPreset: this.config.approvalPolicyPreset,
+      policyReason: null,
     };
+
+    const policy = evaluateApprovalPolicy(this.config.approvalPolicyPreset, {
+      actionType: request.action_type,
+      command: request.command,
+      context: request.context,
+    });
+
+    if (policy.autoApproved) {
+      const response: ApprovalResponse = {
+        approval_id: request.id,
+        decision: 'approved',
+        biometric_verified: true,
+        responded_at: now.toISOString(),
+      };
+      this.decisionLog.push({
+        ...logEntry,
+        decision: 'approved',
+        biometricVerified: true,
+        respondedAt: response.responded_at,
+        autoApproved: true,
+        policyReason: policy.reason,
+      });
+      console.info(`[approval-gate] Auto-approved ${request.id} via ${policy.preset}: ${policy.reason}`);
+      return { approved: true, response, timedOut: false };
+    }
 
     console.info(`[approval-gate] Requesting approval: "${options.title}" (${request.id})`);
 

--- a/openclaw-skills/src/types/protocol.ts
+++ b/openclaw-skills/src/types/protocol.ts
@@ -240,6 +240,7 @@ export type ServerEventType =
   | 'git_state_update'
   | 'git_conflict'
   | 'git_operation_complete'
+  | 'heartbeat'
   | 'connected'
   | 'error';
 
@@ -285,11 +286,20 @@ export interface WsChatMessage {
 export interface ConnectedPayload {
   session_id: string;
   gateway_version: string;
+  heartbeat_interval_ms: number;
 }
 
 export interface ErrorPayload {
   code: number;
   message: string;
+}
+
+export interface GatewayHeartbeatPayload {
+  gateway_version: string;
+  connected_clients: number;
+  last_inbound_at: string | null;
+  last_outbound_at: string | null;
+  uptime_seconds: number;
 }
 
 // ─── Git WebSocket Payloads ───────────────────────────────────────────────────
@@ -348,11 +358,22 @@ export interface ApprovalRespondRequest {
 export interface HealthResponse {
   status: 'ok' | 'degraded';
   version: string;
+  started_at: string;
+  checked_at: string;
   uptime_seconds: number;
   agent_count: number;
   active_tasks: number;
   open_incidents: number;
   pending_approvals: number;
+  websocket_clients: number;
+  last_inbound_ws_at: string | null;
+  last_outbound_ws_at: string | null;
+  approval_policy_preset: string;
+  local_model: {
+    enabled: boolean;
+    base_url: string | null;
+    model: string | null;
+  };
 }
 
 // ─── Error Codes ─────────────────────────────────────────────────────────────

--- a/openclaw-skills/tests/approval-gate-policy.test.ts
+++ b/openclaw-skills/tests/approval-gate-policy.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from '@jest/globals';
+import DEFAULT_CONFIG from '../src/config/default.js';
+import { StateManager } from '../src/gateway/state.js';
+import { ApprovalGateSkill } from '../src/skills/approval-gate.js';
+import type { Agent } from '../src/types/protocol.js';
+
+function makeAgent(): Agent {
+  return {
+    id: 'agent-policy',
+    name: 'Policy Agent',
+    description: 'Policy test agent',
+    status: 'online',
+    workspace: 'test',
+    tags: ['test'],
+    last_active: new Date().toISOString(),
+    active_tasks: 0,
+    pending_approvals: 0,
+  };
+}
+
+describe('ApprovalGateSkill policy presets', () => {
+  test('safe-yolo auto-approves read-only commands without queuing approval', async () => {
+    const state = new StateManager();
+    await state.upsertAgent(makeAgent());
+    const gate = new ApprovalGateSkill(state, {
+      ...DEFAULT_CONFIG,
+      approvalPolicyPreset: 'safe-yolo',
+    });
+
+    const result = await gate.requestApproval({
+      agentId: 'agent-policy',
+      agentName: 'Policy Agent',
+      actionType: 'shell_command',
+      title: 'Inspect git status',
+      description: 'Read repository status',
+      command: 'git status --short',
+      context: {
+        service: 'git',
+        environment: 'development',
+        repository: 'IgorGanapolsky/openclaw-console',
+        riskLevel: 'high',
+      },
+    });
+
+    expect(result.approved).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(state.listPendingApprovals()).toHaveLength(0);
+    expect(gate.getDecisionLog()[0]?.autoApproved).toBe(true);
+  });
+
+  test('manual preset still queues approval requests', async () => {
+    const state = new StateManager();
+    await state.upsertAgent(makeAgent());
+    const gate = new ApprovalGateSkill(state, {
+      ...DEFAULT_CONFIG,
+      approvalPolicyPreset: 'manual',
+    });
+
+    const promise = gate.requestApproval({
+      agentId: 'agent-policy',
+      agentName: 'Policy Agent',
+      actionType: 'shell_command',
+      title: 'Run command',
+      description: 'Needs approval',
+      command: 'git status --short',
+      timeoutMs: 10_000,
+      context: {
+        service: 'git',
+        environment: 'development',
+        repository: 'IgorGanapolsky/openclaw-console',
+        riskLevel: 'high',
+      },
+    });
+
+    const pending = state.listPendingApprovals();
+    expect(pending).toHaveLength(1);
+    state.respondToApproval({
+      approval_id: pending[0]!.id,
+      decision: 'approved',
+      biometric_verified: true,
+      responded_at: new Date().toISOString(),
+    });
+
+    const result = await promise;
+    expect(result.approved).toBe(true);
+    expect(gate.getDecisionLog()[0]?.autoApproved).toBe(false);
+  });
+});

--- a/openclaw-skills/tests/model-provider.test.ts
+++ b/openclaw-skills/tests/model-provider.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import DEFAULT_CONFIG from '../src/config/default.js';
+import { getConfiguredLocalModel, probeLocalModelProvider } from '../src/gateway/model-provider.js';
+import type { GatewayConfig } from '../src/config/default.js';
+
+function config(overrides: Partial<GatewayConfig>): GatewayConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    ...overrides,
+  };
+}
+
+describe('local model provider', () => {
+  test('reports disabled when endpoint or model is missing', () => {
+    const status = getConfiguredLocalModel(config({ localModelBaseUrl: null, localModelName: null }));
+
+    expect(status.enabled).toBe(false);
+    expect(status.base_url).toBeNull();
+    expect(status.model).toBeNull();
+  });
+
+  test('probes /v1/models for OpenAI-compatible local servers', async () => {
+    const fetchImpl = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+
+    const status = await probeLocalModelProvider(
+      config({
+        localModelBaseUrl: 'http://127.0.0.1:8000',
+        localModelName: 'local/nemotron',
+      }),
+      fetchImpl,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe('http://127.0.0.1:8000/v1/models');
+    expect(status.enabled).toBe(true);
+    expect(status.reachable).toBe(true);
+    expect(status.error).toBeNull();
+  });
+
+  test('returns degraded status on failed probe', async () => {
+    const fetchImpl = jest.fn<typeof fetch>().mockRejectedValue(new Error('connection refused'));
+
+    const status = await probeLocalModelProvider(
+      config({
+        localModelBaseUrl: 'http://127.0.0.1:8000',
+        localModelName: 'local/nemotron',
+      }),
+      fetchImpl,
+    );
+
+    expect(status.enabled).toBe(true);
+    expect(status.reachable).toBe(false);
+    expect(status.error).toContain('connection refused');
+  });
+});

--- a/openclaw-skills/tests/policy.test.ts
+++ b/openclaw-skills/tests/policy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from '@jest/globals';
+import { evaluateApprovalPolicy } from '../src/gateway/policy.js';
+import type { ApprovalContext } from '../src/types/protocol.js';
+
+const baseContext: ApprovalContext = {
+  service: 'repo',
+  environment: 'development',
+  repository: 'IgorGanapolsky/openclaw-console',
+  risk_level: 'high',
+};
+
+describe('approval policy presets', () => {
+  test('manual preset never auto-approves', () => {
+    const decision = evaluateApprovalPolicy('manual', {
+      actionType: 'shell_command',
+      command: 'git status',
+      context: baseContext,
+    });
+
+    expect(decision.autoApproved).toBe(false);
+    expect(decision.reason).toContain('manual');
+  });
+
+  test('safe-yolo auto-approves read-only repository inspection', () => {
+    const decision = evaluateApprovalPolicy('safe-yolo', {
+      actionType: 'shell_command',
+      command: 'git status --short',
+      context: baseContext,
+    });
+
+    expect(decision.autoApproved).toBe(true);
+    expect(decision.reason).toContain('read-only');
+  });
+
+  test('ci-yolo auto-approves test commands', () => {
+    const decision = evaluateApprovalPolicy('ci-yolo', {
+      actionType: 'shell_command',
+      command: 'npm test',
+      context: baseContext,
+    });
+
+    expect(decision.autoApproved).toBe(true);
+  });
+
+  test('repo-yolo blocks protected branch pushes', () => {
+    const decision = evaluateApprovalPolicy('repo-yolo', {
+      actionType: 'git_push',
+      command: 'git push origin main',
+      context: {
+        ...baseContext,
+        git_operation: {
+          operation_type: 'push',
+          branch_to: 'main',
+        },
+      },
+    });
+
+    expect(decision.autoApproved).toBe(false);
+    expect(decision.reason).toContain('protected branch');
+  });
+
+  test('danger-yolo still blocks destructive operations', () => {
+    const decision = evaluateApprovalPolicy('danger-yolo', {
+      actionType: 'destructive',
+      command: 'rm -rf /',
+      context: baseContext,
+    });
+
+    expect(decision.autoApproved).toBe(false);
+    expect(decision.reason).toContain('never');
+  });
+});

--- a/openclaw-skills/tests/protocol.test.ts
+++ b/openclaw-skills/tests/protocol.test.ts
@@ -133,7 +133,7 @@ describe('Protocol model serialisation', () => {
 
 describe('WebSocket message envelope', () => {
   test('Envelope wraps payload with type and timestamp', () => {
-    const payload: ConnectedPayload = { session_id: 'abc', gateway_version: '1.0.0' };
+    const payload: ConnectedPayload = { session_id: 'abc', gateway_version: '1.0.0', heartbeat_interval_ms: 10_000 };
     const msg: WebSocketMessage<ConnectedPayload> = {
       type: 'connected',
       payload,
@@ -142,6 +142,7 @@ describe('WebSocket message envelope', () => {
     const parsed = JSON.parse(JSON.stringify(msg)) as WebSocketMessage<ConnectedPayload>;
     expect(parsed.type).toBe('connected');
     expect(parsed.payload.session_id).toBe('abc');
+    expect(parsed.payload.heartbeat_interval_ms).toBe(10_000);
     expect(parsed.timestamp).toBeTruthy();
   });
 


### PR DESCRIPTION
## What changed

Implements the highest-ROI operational runtime pieces from the NemoClaw/OpenShell checklist in `openclaw-skills`:

- Adds gateway runtime status visibility via `/api/runtime/status`.
- Expands `/api/health` with timestamps, WebSocket activity, approval policy, and local model configuration.
- Adds WebSocket heartbeat events so clients can show that the gateway is alive and working during long waits.
- Adds OpenAI-compatible local model provider status probing via `/api/model/status` for vLLM/Nemotron-style local endpoints.
- Adds approval policy presets: `manual`, `safe-yolo`, `ci-yolo`, `repo-yolo`, and `danger-yolo`.
- Integrates approval policy auto-approval into `ApprovalGateSkill` with audit log evidence.

## Why

This directly addresses the operational gaps from the checklist:

- OpenClaw should not look idle for minutes without a signal.
- Local model endpoints should be visible and health-checkable before routing agent work to them.
- “Yolo mode” should be policy-driven, auditable, and bounded instead of raw global bypasses.

## Configuration

New env vars:

- `OPENCLAW_APPROVAL_POLICY=manual|safe-yolo|ci-yolo|repo-yolo|danger-yolo`
- `OPENCLAW_HEARTBEAT_INTERVAL_MS=10000`
- `OPENCLAW_LOCAL_MODEL_BASE_URL=http://127.0.0.1:8000`
- `OPENCLAW_LOCAL_MODEL_NAME=local/nemotron`
- `OPENCLAW_LOCAL_MODEL_TIMEOUT_MS=2500`

## Verification

Commands run from `openclaw-skills`:

- `npm ci`
- `npm test -- --runTestsByPath tests/policy.test.ts tests/model-provider.test.ts tests/approval-gate-policy.test.ts tests/protocol.test.ts`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `npm run lint`
- `npm audit --audit-level=high`

Observed results:

- Targeted tests: 4 suites passed, 36 tests passed.
- Full tests: 8 suites passed, 93 tests passed.
- Build exited 0.
- Lint exited 0.
- Audit exited 0 for high-severity threshold; npm reported 8 low-severity transitive findings under `firebase-admin`.

## Smoke Test Evidence

Started built gateway with:

- `PORT=18889`
- `OPENCLAW_APPROVAL_POLICY=safe-yolo`
- `OPENCLAW_LOCAL_MODEL_BASE_URL=http://127.0.0.1:8000`
- `OPENCLAW_LOCAL_MODEL_NAME=local/nemotron`
- `OPENCLAW_HEARTBEAT_INTERVAL_MS=1000`

Verified:

- `/api/health` returned `status: ok`, `approval_policy_preset: safe-yolo`, local model config enabled, and timestamp fields.
- `/api/runtime/status` returned gateway uptime, approval policy, local model config, and WebSocket runtime snapshot.
- `/api/model/status` returned `enabled: true`, `model: local/nemotron`, `reachable: false`, `error: fetch failed` because no local vLLM server was listening on `127.0.0.1:8000` during the smoke test.
- WebSocket emitted `connected` with `heartbeat_interval_ms: 1000`, then emitted `heartbeat` with `connected_clients: 1` and timestamp fields.
- Smoke server was stopped; port `18889` had no remaining listener.
