### PR TITLE
feat: add high-roi orchestration signals

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -49,6 +49,18 @@ jobs:
             const FAILING_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required", "startup_failure", "stale"]);
             const FAILING_STATES = new Set(["error", "failure"]);
             const PENDING_STATES = new Set(["pending"]);
+            const REQUIRED_CHECK_WORKFLOWS = new Map([
+              ["Skills Tests", "ci.yml"],
+              ["Architecture Lint (Kotlin)", "ci.yml"],
+              ["Architecture Lint (Swift)", "ci.yml"],
+              ["Android Build Check", "ci.yml"],
+              ["iOS Build Check", "ci.yml"],
+              ["Secrets Scan", "security.yml"],
+              ["Dependency Audit", "security.yml"],
+              ["CodeQL Analysis (java-kotlin)", "security.yml"],
+              ["CodeQL Analysis (javascript-typescript)", "security.yml"],
+              ["CodeQL Analysis (swift)", "security.yml"]
+            ]);
             const DEFAULT_REQUIRED_CHECKS = {
               develop: ["Skills Tests", "Architecture Lint (Kotlin)", "Architecture Lint (Swift)"],
               main: [
@@ -229,9 +241,18 @@ jobs:
             }
 
             async function triggerMissingRequiredChecks(pr, missingRequiredCheckNames) {
-              const ciChecks = new Set(["Skills Tests", "Architecture Lint (Kotlin)", "Architecture Lint (Swift)"]);
-              if (missingRequiredCheckNames.some((name) => ciChecks.has(name))) {
-                await triggerWorkflow("ci.yml", pr.head.ref);
+              const workflows = new Set();
+              for (const name of missingRequiredCheckNames) {
+                const workflow = REQUIRED_CHECK_WORKFLOWS.get(name);
+                if (workflow) {
+                  workflows.add(workflow);
+                } else {
+                  core.warning(`PR #${pr.number}: no autonomous dispatch mapping for missing required check "${name}".`);
+                }
+              }
+
+              for (const workflow of workflows) {
+                await triggerWorkflow(workflow, pr.head.ref);
               }
             }
 

--- a/android/app/src/main/java/com/openclaw/console/data/model/WebSocketEvent.kt
+++ b/android/app/src/main/java/com/openclaw/console/data/model/WebSocketEvent.kt
@@ -1,7 +1,20 @@
 package com.openclaw.console.data.model
 
 sealed class WebSocketEvent {
-    data class Connected(val sessionId: String, val gatewayVersion: String) : WebSocketEvent()
+    data class Connected(
+        val sessionId: String,
+        val gatewayVersion: String,
+        val heartbeatIntervalMs: Int,
+        val timestamp: String?
+    ) : WebSocketEvent()
+    data class Heartbeat(
+        val gatewayVersion: String,
+        val connectedClients: Int,
+        val lastInboundAt: String?,
+        val lastOutboundAt: String?,
+        val uptimeSeconds: Long,
+        val timestamp: String?
+    ) : WebSocketEvent()
     data class AgentUpdate(val agentStatus: Agent) : WebSocketEvent()
     data class TaskUpdate(val update: com.openclaw.console.data.model.TaskUpdate) : WebSocketEvent()
     data class TaskStepAdded(val step: TaskStep) : WebSocketEvent()

--- a/android/app/src/main/java/com/openclaw/console/data/network/WebSocketClient.kt
+++ b/android/app/src/main/java/com/openclaw/console/data/network/WebSocketClient.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -125,7 +126,18 @@ open class WebSocketClient(
                     "connected" -> {
                         val sessionId = msg.payload["session_id"]?.jsonPrimitive?.content ?: ""
                         val version = msg.payload["gateway_version"]?.jsonPrimitive?.content ?: ""
-                        WebSocketEvent.Connected(sessionId, version)
+                        val heartbeatIntervalMs = msg.payload["heartbeat_interval_ms"]?.jsonPrimitive?.content?.toIntOrNull() ?: 0
+                        WebSocketEvent.Connected(sessionId, version, heartbeatIntervalMs, msg.timestamp)
+                    }
+                    "heartbeat" -> {
+                        WebSocketEvent.Heartbeat(
+                            gatewayVersion = msg.payload["gateway_version"]?.jsonPrimitive?.content ?: "",
+                            connectedClients = msg.payload["connected_clients"]?.jsonPrimitive?.content?.toIntOrNull() ?: 0,
+                            lastInboundAt = msg.payload["last_inbound_at"]?.jsonPrimitive?.contentOrNull,
+                            lastOutboundAt = msg.payload["last_outbound_at"]?.jsonPrimitive?.contentOrNull,
+                            uptimeSeconds = msg.payload["uptime_seconds"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L,
+                            timestamp = msg.timestamp
+                        )
                     }
                     "agent_update" -> {
                         val agent = json.decodeFromJsonElement(Agent.serializer(), msg.payload)

--- a/android/app/src/main/java/com/openclaw/console/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/AppViewModel.kt
@@ -5,12 +5,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.openclaw.console.data.model.GatewayConnection
+import com.openclaw.console.data.model.WebSocketEvent
 import com.openclaw.console.data.network.ApiService
 import com.openclaw.console.data.network.ConnectionState
 import com.openclaw.console.data.network.WebSocketClient
 import com.openclaw.console.data.repository.*
 import com.openclaw.console.service.SecureStorage
 import com.openclaw.console.service.NotificationService
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
@@ -18,6 +21,7 @@ import kotlinx.coroutines.launch
  * App-level ViewModel that owns the active gateway connection and shared repositories.
  * Survives configuration changes as it lives at the Activity level.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class AppViewModel(private val application: Application) : ViewModel() {
 
     val secureStorage = SecureStorage(application)
@@ -25,6 +29,7 @@ class AppViewModel(private val application: Application) : ViewModel() {
 
     private val _wsClient = MutableStateFlow<WebSocketClient?>(null)
     private val _apiService = MutableStateFlow<ApiService?>(null)
+    private var gatewaySignalJob: Job? = null
 
     // Exposed repos (null until a gateway is connected)
     private val _agentRepository = MutableStateFlow<AgentRepository?>(null)
@@ -50,6 +55,12 @@ class AppViewModel(private val application: Application) : ViewModel() {
             ws?.connectionState ?: MutableStateFlow(ConnectionState.DISCONNECTED)
         }
         .stateIn(viewModelScope, SharingStarted.Eagerly, ConnectionState.DISCONNECTED)
+
+    private val _lastGatewaySignal = MutableStateFlow<String?>(null)
+    val lastGatewaySignal: StateFlow<String?> = _lastGatewaySignal
+
+    private val _gatewaySignalSummary = MutableStateFlow("No gateway signal yet")
+    val gatewaySignalSummary: StateFlow<String> = _gatewaySignalSummary
 
     val pendingApprovalCount: StateFlow<Int> = _approvalRepository
         .flatMapLatest { repo ->
@@ -89,6 +100,7 @@ class AppViewModel(private val application: Application) : ViewModel() {
         _approvalRepository.value = ApprovalRepository(api, ws, NotificationService.getInstance(application))
 
         ws.connect()
+        observeGatewaySignals(ws)
 
         // Initial data load
         viewModelScope.launch {
@@ -103,7 +115,38 @@ class AppViewModel(private val application: Application) : ViewModel() {
         gatewayRepository.updateLastConnected(gateway.id, java.time.Instant.now().toString())
     }
 
+    private fun observeGatewaySignals(ws: WebSocketClient) {
+        gatewaySignalJob?.cancel()
+        gatewaySignalJob = viewModelScope.launch {
+            ws.events.collect { event ->
+                when (event) {
+                    is WebSocketEvent.Connected -> {
+                        _lastGatewaySignal.value = event.timestamp ?: java.time.Instant.now().toString()
+                        _gatewaySignalSummary.value = "Connected • heartbeat every ${event.heartbeatIntervalMs / 1000}s"
+                    }
+                    is WebSocketEvent.Heartbeat -> {
+                        _lastGatewaySignal.value = event.timestamp ?: java.time.Instant.now().toString()
+                        _gatewaySignalSummary.value = "Working • ${event.connectedClients} client(s) • uptime ${event.uptimeSeconds}s"
+                    }
+                    is WebSocketEvent.Reconnecting -> {
+                        _lastGatewaySignal.value = java.time.Instant.now().toString()
+                        _gatewaySignalSummary.value = "Reconnecting in ${event.delayMs / 1000}s"
+                    }
+                    WebSocketEvent.Disconnected -> {
+                        _lastGatewaySignal.value = java.time.Instant.now().toString()
+                        _gatewaySignalSummary.value = "Disconnected"
+                    }
+                    else -> {
+                        _lastGatewaySignal.value = java.time.Instant.now().toString()
+                    }
+                }
+            }
+        }
+    }
+
     fun disconnect() {
+        gatewaySignalJob?.cancel()
+        gatewaySignalJob = null
         _wsClient.value?.dispose()
         _wsClient.value = null
         _apiService.value = null

--- a/android/app/src/main/java/com/openclaw/console/ui/components/SharedComponents.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/components/SharedComponents.kt
@@ -242,16 +242,19 @@ fun EmptyState(
 @Composable
 fun ConnectionStatusBanner(
     state: com.openclaw.console.data.network.ConnectionState,
+    lastSignalAt: String? = null,
+    signalSummary: String? = null,
     modifier: Modifier = Modifier
 ) {
-    val (message, color) = when (state) {
-        com.openclaw.console.data.network.ConnectionState.CONNECTED -> return
+    val (message, color, icon) = when (state) {
+        com.openclaw.console.data.network.ConnectionState.CONNECTED ->
+            Triple(signalSummary ?: "Connected", Color(0xFFE8F5E9), Icons.Default.Cloud)
         com.openclaw.console.data.network.ConnectionState.CONNECTING ->
-            "Connecting..." to MaterialTheme.colorScheme.primaryContainer
+            Triple("Connecting...", MaterialTheme.colorScheme.primaryContainer, Icons.Default.Sync)
         com.openclaw.console.data.network.ConnectionState.RECONNECTING ->
-            "Reconnecting..." to MaterialTheme.colorScheme.tertiaryContainer
+            Triple("Reconnecting...", MaterialTheme.colorScheme.tertiaryContainer, Icons.Default.Sync)
         com.openclaw.console.data.network.ConnectionState.DISCONNECTED ->
-            "Disconnected - Go to Settings to connect" to MaterialTheme.colorScheme.errorContainer
+            Triple("Disconnected - Go to Settings to connect", MaterialTheme.colorScheme.errorContainer, Icons.Default.CloudOff)
     }
     Surface(
         modifier = modifier.fillMaxWidth(),
@@ -266,12 +269,21 @@ fun ConnectionStatusBanner(
                 state == com.openclaw.console.data.network.ConnectionState.RECONNECTING) {
                 CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp)
             } else {
-                Icon(Icons.Default.CloudOff, contentDescription = null, modifier = Modifier.size(16.dp))
+                Icon(icon, contentDescription = null, modifier = Modifier.size(16.dp))
             }
-            Text(
-                text = message,
-                style = MaterialTheme.typography.bodySmall
-            )
+            Column {
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall
+                )
+                lastSignalAt?.let {
+                    Text(
+                        text = "Last signal: ${formatTimeAgo(it)}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/bridges/BridgeListScreen.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/bridges/BridgeListScreen.kt
@@ -20,6 +20,7 @@ import com.openclaw.console.data.model.BridgeSession
 import com.openclaw.console.data.model.BridgeSessionType
 import com.openclaw.console.ui.AppViewModel
 import com.openclaw.console.ui.components.*
+import kotlinx.serialization.json.jsonPrimitive
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -174,6 +175,13 @@ private fun BridgeSessionItem(session: BridgeSession) {
                         .padding(horizontal = 4.dp, vertical = 2.dp),
                     fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
                 )
+                session.metadata?.get("project_name")?.jsonPrimitive?.content?.let { projectName ->
+                    Text(
+                        text = "Project session: $projectName",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
                 TimeAgoText(session.createdAt, style = MaterialTheme.typography.labelSmall)
             }
         }

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/settings/SettingsScreen.kt
@@ -35,6 +35,8 @@ fun SettingsScreen(
         derivedStateOf { approvalRepo?.pendingApprovals?.value ?: emptyList() }
     }
     val connectionState by appViewModel.connectionState.collectAsStateWithLifecycle()
+    val lastGatewaySignal by appViewModel.lastGatewaySignal.collectAsStateWithLifecycle()
+    val gatewaySignalSummary by appViewModel.gatewaySignalSummary.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.setRepository(gatewayRepo)
@@ -64,7 +66,11 @@ fun SettingsScreen(
         ) {
             // Connection status
             item {
-                ConnectionStatusBanner(state = connectionState)
+                ConnectionStatusBanner(
+                    state = connectionState,
+                    lastSignalAt = lastGatewaySignal,
+                    signalSummary = gatewaySignalSummary
+                )
             }
 
             // Pending approvals section

--- a/android/app/src/test/java/com/openclaw/console/data/network/WebSocketClientTest.kt
+++ b/android/app/src/test/java/com/openclaw/console/data/network/WebSocketClientTest.kt
@@ -116,7 +116,7 @@ class WebSocketClientTest {
         client.setConnectionState(ConnectionState.CONNECTED)
         advanceUntilIdle()
 
-        client.emitEvent(WebSocketEvent.Connected("session-123", "1.0.0"))
+        client.emitEvent(WebSocketEvent.Connected("session-123", "1.0.0", 10_000, "2026-04-15T12:00:00Z"))
         advanceUntilIdle()
 
         // Verify state progression
@@ -139,7 +139,7 @@ class WebSocketClientTest {
 
         client.connect()
         client.setConnectionState(ConnectionState.CONNECTED)
-        client.emitEvent(WebSocketEvent.Connected("session-123", "1.0.0"))
+        client.emitEvent(WebSocketEvent.Connected("session-123", "1.0.0", 10_000, "2026-04-15T12:00:00Z"))
 
         // Simulate connection failure with reconnection event
         client.setConnectionState(ConnectionState.DISCONNECTED)

--- a/ios/OpenClawConsole/OpenClawConsole/Models/GatewayConnection.swift
+++ b/ios/OpenClawConsole/OpenClawConsole/Models/GatewayConnection.swift
@@ -43,11 +43,39 @@ struct HealthResponse: Codable {
     let status: String
     let version: String?
     let gatewayVersion: String?
+    let startedAt: Date?
+    let checkedAt: Date?
+    let uptimeSeconds: Int?
+    let websocketClients: Int?
+    let lastInboundWsAt: Date?
+    let lastOutboundWsAt: Date?
+    let approvalPolicyPreset: String?
+    let localModel: LocalModelStatus?
 
     enum CodingKeys: String, CodingKey {
         case status
         case version
         case gatewayVersion = "gateway_version"
+        case startedAt = "started_at"
+        case checkedAt = "checked_at"
+        case uptimeSeconds = "uptime_seconds"
+        case websocketClients = "websocket_clients"
+        case lastInboundWsAt = "last_inbound_ws_at"
+        case lastOutboundWsAt = "last_outbound_ws_at"
+        case approvalPolicyPreset = "approval_policy_preset"
+        case localModel = "local_model"
+    }
+}
+
+struct LocalModelStatus: Codable, Hashable {
+    let enabled: Bool
+    let baseURL: String?
+    let model: String?
+
+    enum CodingKeys: String, CodingKey {
+        case enabled
+        case baseURL = "base_url"
+        case model
     }
 }
 

--- a/ios/OpenClawConsole/OpenClawConsole/Models/WebSocketMessage.swift
+++ b/ios/OpenClawConsole/OpenClawConsole/Models/WebSocketMessage.swift
@@ -131,6 +131,7 @@ enum InboundEventType: String {
     case bridgeSessionUpdate = "bridge_session_update"
     case recurringTaskUpdated = "recurring_task_updated"
     case gitStateChanged = "git_state_changed"
+    case heartbeat
     case connected
     case error
 }
@@ -148,7 +149,8 @@ enum InboundEvent {
     case bridgeSessionUpdate(BridgeSession)
     case recurringTaskUpdated(RecurringTask)
     case gitStateChanged(String, GitState)
-    case connected(sessionId: String, gatewayVersion: String)
+    case heartbeat(GatewayHeartbeatPayload, timestamp: Date?)
+    case connected(sessionId: String, gatewayVersion: String, heartbeatIntervalMs: Int, timestamp: Date?)
     case error(code: Int, message: String)
     case unknown(String)
 }
@@ -216,10 +218,28 @@ struct BridgeSession: Codable, Identifiable {
 struct ConnectedPayload: Codable {
     let sessionId: String
     let gatewayVersion: String
+    let heartbeatIntervalMs: Int
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
         case gatewayVersion = "gateway_version"
+        case heartbeatIntervalMs = "heartbeat_interval_ms"
+    }
+}
+
+struct GatewayHeartbeatPayload: Codable {
+    let gatewayVersion: String
+    let connectedClients: Int
+    let lastInboundAt: Date?
+    let lastOutboundAt: Date?
+    let uptimeSeconds: Int
+
+    enum CodingKeys: String, CodingKey {
+        case gatewayVersion = "gateway_version"
+        case connectedClients = "connected_clients"
+        case lastInboundAt = "last_inbound_at"
+        case lastOutboundAt = "last_outbound_at"
+        case uptimeSeconds = "uptime_seconds"
     }
 }
 

--- a/ios/OpenClawConsole/OpenClawConsole/Services/WebSocketService.swift
+++ b/ios/OpenClawConsole/OpenClawConsole/Services/WebSocketService.swift
@@ -13,12 +13,26 @@ enum ConnectionState: Equatable {
 
 final class WebSocketService: NSObject, ObservableObject {
 
+    private struct ParsedEnvelope {
+        let type: String
+        let eventType: InboundEventType?
+        let payloadData: Data
+        let timestamp: Date
+    }
+
     @Published var connectionState: ConnectionState = .disconnected
     @Published var lastEvent: InboundEvent?
+    @Published var lastEventTimestamp: Date?
+    @Published var lastHeartbeat: GatewayHeartbeatPayload?
+    @Published var lastActivityAt: Date?
 
     private var webSocketTask: URLSessionWebSocketTask?
     private let urlSession: URLSession
-    private let decoder = JSONDecoder()
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
     private var reconnectAttempt = 0
     private let maxReconnectAttempts = 5
 
@@ -126,7 +140,7 @@ final class WebSocketService: NSObject, ObservableObject {
         if reconnectAttempt < maxReconnectAttempts {
             reconnectAttempt += 1
             let delay = pow(2.0, Double(reconnectAttempt))
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
                 // Logic to reconnect if URL/token are stored
             }
         }
@@ -134,85 +148,107 @@ final class WebSocketService: NSObject, ObservableObject {
 
     private func parseMessage(_ text: String) {
         guard let data = text.data(using: .utf8) else { return }
+        guard let envelope = parseEnvelope(data) else { return }
 
-        // Decode type field first
-        guard let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let type = raw["type"] as? String else { return }
-
-        let payloadData: Data
-        if let payload = raw["payload"] {
-            payloadData = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data()
-        } else {
-            payloadData = Data()
-        }
-
-        guard let eventType = InboundEventType(rawValue: type) else {
-            eventSubject.send(.unknown(type))
-            lastEvent = .unknown(type)
+        guard let eventType = envelope.eventType else {
+            publish(.unknown(envelope.type), timestamp: envelope.timestamp)
             return
         }
 
-        var event: InboundEvent?
+        guard let event = decodeEvent(
+            eventType,
+            payloadData: envelope.payloadData,
+            timestamp: envelope.timestamp
+        ) else { return }
+        publish(event, timestamp: envelope.timestamp)
+    }
 
+    private func parseEnvelope(_ data: Data) -> ParsedEnvelope? {
+        let decodedEnvelope = try? decoder.decode(WebSocketEnvelope.self, from: data)
+        let timestamp = decodedEnvelope?.timestamp ?? Date()
+
+        guard let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = raw["type"] as? String else { return nil }
+
+        let payloadData = payloadData(from: raw["payload"])
+        let eventType = InboundEventType(rawValue: type)
+        return ParsedEnvelope(type: type, eventType: eventType, payloadData: payloadData, timestamp: timestamp)
+    }
+
+    private func payloadData(from payload: Any?) -> Data {
+        guard let payload else { return Data() }
+        return (try? JSONSerialization.data(withJSONObject: payload)) ?? Data()
+    }
+
+    private func decodeEvent(
+        _ eventType: InboundEventType,
+        payloadData: Data,
+        timestamp: Date
+    ) -> InboundEvent? {
         switch eventType {
         case .agentUpdate:
-            if let obj = try? decoder.decode(AgentStatusUpdate.self, from: payloadData) {
-                event = .agentUpdate(obj)
-            }
+            return decode(AgentStatusUpdate.self, from: payloadData).map(InboundEvent.agentUpdate)
         case .taskUpdate:
-            if let obj = try? decoder.decode(OCTaskUpdate.self, from: payloadData) {
-                event = .taskUpdate(obj)
-            }
+            return decode(OCTaskUpdate.self, from: payloadData).map(InboundEvent.taskUpdate)
         case .taskStep:
-            if let obj = try? decoder.decode(TaskStep.self, from: payloadData) {
-                event = .taskStep(obj)
-            }
+            return decode(TaskStep.self, from: payloadData).map(InboundEvent.taskStep)
         case .incidentNew:
-            if let obj = try? decoder.decode(Incident.self, from: payloadData) {
-                event = .incidentNew(obj)
-            }
+            return decode(Incident.self, from: payloadData).map(InboundEvent.incidentNew)
         case .incidentUpdate:
-            if let obj = try? decoder.decode(IncidentUpdate.self, from: payloadData) {
-                event = .incidentUpdate(obj)
-            }
+            return decode(IncidentUpdate.self, from: payloadData).map(InboundEvent.incidentUpdate)
         case .approvalRequest:
-            if let obj = try? decoder.decode(ApprovalRequest.self, from: payloadData) {
-                event = .approvalRequest(obj)
-            }
+            return decode(ApprovalRequest.self, from: payloadData).map(InboundEvent.approvalRequest)
         case .chatResponse:
-            if let obj = try? decoder.decode(ChatMessage.self, from: payloadData) {
-                event = .chatResponse(obj)
-            }
+            return decode(ChatMessage.self, from: payloadData).map(InboundEvent.chatResponse)
         case .bridgeSessionNew:
-            if let obj = try? decoder.decode(BridgeSession.self, from: payloadData) {
-                event = .bridgeSessionNew(obj)
-            }
+            return decode(BridgeSession.self, from: payloadData).map(InboundEvent.bridgeSessionNew)
         case .bridgeSessionUpdate:
-            if let obj = try? decoder.decode(BridgeSession.self, from: payloadData) {
-                event = .bridgeSessionUpdate(obj)
-            }
+            return decode(BridgeSession.self, from: payloadData).map(InboundEvent.bridgeSessionUpdate)
         case .recurringTaskUpdated:
-            if let obj = try? decoder.decode(RecurringTask.self, from: payloadData) {
-                event = .recurringTaskUpdated(obj)
-            }
+            return decode(RecurringTask.self, from: payloadData).map(InboundEvent.recurringTaskUpdated)
         case .gitStateChanged:
-            // Handled via other mechanisms or simple notification
-            break
+            return nil
+        case .heartbeat:
+            return decodeHeartbeat(payloadData, timestamp: timestamp)
         case .connected:
-            if let obj = try? decoder.decode(ConnectedPayload.self, from: payloadData) {
-                event = .connected(sessionId: obj.sessionId, gatewayVersion: obj.gatewayVersion)
-                reconnectAttempt = 0
-                connectionState = .connected(sessionId: obj.sessionId)
-            }
+            return decodeConnected(payloadData, timestamp: timestamp)
         case .error:
-            if let obj = try? decoder.decode(ErrorPayload.self, from: payloadData) {
-                event = .error(code: obj.code, message: obj.message)
-            }
+            return decode(ErrorPayload.self, from: payloadData).map { .error(code: $0.code, message: $0.message) }
         }
+    }
 
-        if let event {
-            eventSubject.send(event)
-            lastEvent = event
+    private func decode<T: Decodable>(_ type: T.Type, from data: Data) -> T? {
+        try? decoder.decode(type, from: data)
+    }
+
+    private func decodeHeartbeat(_ payloadData: Data, timestamp: Date) -> InboundEvent? {
+        guard let heartbeat = decode(GatewayHeartbeatPayload.self, from: payloadData) else { return nil }
+        DispatchQueue.main.async { [weak self] in
+            self?.lastHeartbeat = heartbeat
+        }
+        return .heartbeat(heartbeat, timestamp: timestamp)
+    }
+
+    private func decodeConnected(_ payloadData: Data, timestamp: Date) -> InboundEvent? {
+        guard let connected = decode(ConnectedPayload.self, from: payloadData) else { return nil }
+        reconnectAttempt = 0
+        DispatchQueue.main.async { [weak self] in
+            self?.connectionState = .connected(sessionId: connected.sessionId)
+        }
+        return .connected(
+            sessionId: connected.sessionId,
+            gatewayVersion: connected.gatewayVersion,
+            heartbeatIntervalMs: connected.heartbeatIntervalMs,
+            timestamp: timestamp
+        )
+    }
+
+    private func publish(_ event: InboundEvent, timestamp: Date) {
+        eventSubject.send(event)
+        DispatchQueue.main.async { [weak self] in
+            self?.lastEvent = event
+            self?.lastEventTimestamp = timestamp
+            self?.lastActivityAt = timestamp
         }
     }
 

--- a/ios/OpenClawConsole/OpenClawConsole/ViewModels/GatewayManager.swift
+++ b/ios/OpenClawConsole/OpenClawConsole/ViewModels/GatewayManager.swift
@@ -29,6 +29,7 @@ final class GatewayManager {
 
     // Connection status per gateway id
     private(set) var connectionStatuses: [String: GatewayConnectionStatus] = [:]
+    private(set) var gatewayHealth: [String: HealthResponse] = [:]
 
     // MARK: Private
 
@@ -129,7 +130,8 @@ final class GatewayManager {
         connectionStatuses[gateway.id] = .checking
 
         do {
-            _ = try await APIService.shared.healthCheck(gateway: gateway)
+            let health = try await APIService.shared.healthCheck(gateway: gateway)
+            gatewayHealth[gateway.id] = health
             connectionStatuses[gateway.id] = .connected
         } catch let error as OpenClawError {
             connectionStatuses[gateway.id] = .failed(error.localizedDescription)
@@ -140,5 +142,9 @@ final class GatewayManager {
 
     func connectionStatus(for gateway: GatewayConnection) -> GatewayConnectionStatus {
         connectionStatuses[gateway.id] ?? .unknown
+    }
+
+    func health(for gateway: GatewayConnection) -> HealthResponse? {
+        gatewayHealth[gateway.id]
     }
 }

--- a/ios/OpenClawConsole/OpenClawConsole/Views/Bridges/BridgeListView.swift
+++ b/ios/OpenClawConsole/OpenClawConsole/Views/Bridges/BridgeListView.swift
@@ -67,6 +67,12 @@ struct BridgeSessionRow: View {
                     .padding(4)
                     .background(Color.secondary.opacity(0.1))
                     .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                if let projectName {
+                    Text("Project session: \(projectName)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Text("Created: \(session.createdAt.formatted(date: .abbreviated, time: .shortened))")
@@ -82,6 +88,10 @@ struct BridgeSessionRow: View {
         case "terminal": return "terminal"
         default: return "link"
         }
+    }
+
+    private var projectName: String? {
+        session.metadata["project_name"]?.value as? String
     }
 }
 

--- a/ios/OpenClawConsole/OpenClawConsole/Views/Settings/GatewayListView.swift
+++ b/ios/OpenClawConsole/OpenClawConsole/Views/Settings/GatewayListView.swift
@@ -97,6 +97,12 @@ private struct GatewayRow: View {
                         .font(.caption2)
                         .foregroundStyle(.orange)
                 }
+
+                if let health = gatewayManager.health(for: gateway) {
+                    Text(runtimeSummary(health))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Spacer()
@@ -159,5 +165,12 @@ private struct GatewayRow: View {
             }
         }
         .frame(minHeight: 44)
+    }
+
+    private func runtimeSummary(_ health: HealthResponse) -> String {
+        let policy = health.approvalPolicyPreset ?? "manual"
+        let clients = health.websocketClients ?? 0
+        let checked = health.checkedAt?.formatted(date: .omitted, time: .shortened) ?? "unknown"
+        return "Policy: \(policy) • WS clients: \(clients) • Checked: \(checked)"
     }
 }

--- a/openclaw-skills/eslint.config.mjs
+++ b/openclaw-skills/eslint.config.mjs
@@ -10,6 +10,7 @@ export default tseslint.config(
         projectService: {
           allowDefaultProject: ['tests/*.ts', 'tests/*/*.ts', 'tests/*/*/*.ts'],
           defaultProject: 'tsconfig.test.json',
+          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 20,
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/openclaw-skills/src/config/default.ts
+++ b/openclaw-skills/src/config/default.ts
@@ -2,6 +2,8 @@
  * Default configuration for the OpenClaw gateway.
  */
 
+export type ApprovalPolicyPreset = 'manual' | 'safe-yolo' | 'repo-yolo' | 'ci-yolo' | 'danger-yolo';
+
 export interface GatewayConfig {
   /** HTTP/WS listen port */
   port: number;
@@ -32,7 +34,7 @@ export interface GatewayConfig {
   /** CORS allowed origins ('*' for all) */
   corsOrigins: string;
   /** Approval automation preset. manual keeps every gate human-driven. */
-  approvalPolicyPreset: 'manual' | 'safe-yolo' | 'repo-yolo' | 'ci-yolo' | 'danger-yolo';
+  approvalPolicyPreset: ApprovalPolicyPreset;
   /** How frequently WebSocket clients receive heartbeat/status events */
   heartbeatIntervalMs: number;
   /** Local OpenAI-compatible model endpoint, e.g. vLLM on Jetson */
@@ -65,8 +67,12 @@ const DEFAULT_CONFIG: GatewayConfig = {
   localModelTimeoutMs: parseInt(process.env['OPENCLAW_LOCAL_MODEL_TIMEOUT_MS'] ?? '2500', 10),
 };
 
-function parseApprovalPolicyPreset(raw: string): GatewayConfig['approvalPolicyPreset'] {
-  if (raw === 'safe-yolo' || raw === 'repo-yolo' || raw === 'ci-yolo' || raw === 'danger-yolo') {
+export function isApprovalPolicyPreset(raw: string): raw is ApprovalPolicyPreset {
+  return raw === 'manual' || raw === 'safe-yolo' || raw === 'repo-yolo' || raw === 'ci-yolo' || raw === 'danger-yolo';
+}
+
+export function parseApprovalPolicyPreset(raw: string): ApprovalPolicyPreset {
+  if (isApprovalPolicyPreset(raw)) {
     return raw;
   }
   return 'manual';

--- a/openclaw-skills/src/gateway/project-session.ts
+++ b/openclaw-skills/src/gateway/project-session.ts
@@ -1,0 +1,76 @@
+import crypto from 'node:crypto';
+import path from 'node:path';
+import type { BridgeSession } from '../types/protocol.js';
+
+export interface ProjectBridgeSessionMetadata {
+  original_session_id: string;
+  project_name: string;
+  project_root: string;
+  project_session_id: string;
+  session_scope: 'project';
+}
+
+export function normalizeProjectBridgeSession(input: BridgeSession): BridgeSession {
+  const cwd = input.cwd || process.cwd();
+  const projectName = slugify(path.basename(cwd) || 'workspace');
+  const projectHash = crypto.createHash('sha256').update(cwd).digest('hex').slice(0, 10);
+  const projectSessionId = `project:${projectName}:${projectHash}`;
+  const originalSessionId = typeof input.metadata?.['original_session_id'] === 'string'
+    ? input.metadata['original_session_id']
+    : input.id;
+  const metadata = {
+    ...input.metadata,
+    original_session_id: originalSessionId,
+    project_name: projectName,
+    project_root: cwd,
+    project_session_id: projectSessionId,
+    session_scope: 'project',
+  } satisfies BridgeSession['metadata'] & ProjectBridgeSessionMetadata;
+
+  return {
+    ...input,
+    id: projectSessionId,
+    title: input.title || `OpenClaw: ${projectName}`,
+    cwd,
+    metadata,
+  };
+}
+
+function slugify(value: string): string {
+  let slug = '';
+  let pendingSeparator = false;
+
+  for (const character of value.toLowerCase()) {
+    const code = character.charCodeAt(0);
+    const isLowercaseLetter = code >= 97 && code <= 122;
+    const isDigit = code >= 48 && code <= 57;
+    const isSafePunctuation = character === '.' || character === '_' || character === '-';
+
+    if (isLowercaseLetter || isDigit || isSafePunctuation) {
+      if (pendingSeparator && slug.length > 0 && slug.at(-1) !== '-') {
+        slug += '-';
+      }
+      slug += character;
+      pendingSeparator = false;
+    } else {
+      pendingSeparator = true;
+    }
+  }
+
+  return trimHyphens(slug) || 'workspace';
+}
+
+function trimHyphens(value: string): string {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && value[start] === '-') {
+    start += 1;
+  }
+
+  while (end > start && value[end - 1] === '-') {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
+}

--- a/openclaw-skills/src/gateway/server.ts
+++ b/openclaw-skills/src/gateway/server.ts
@@ -24,12 +24,16 @@ import type {
   ApprovalRespondRequest,
   HealthResponse,
   ApprovalResponse,
+  RuntimeConfigResponse,
+  RuntimeConfigUpdateRequest,
 } from '../types/protocol.js';
 import { ERROR_CODES } from '../types/protocol.js';
 import { createBillingRouter } from '../billing/revenuecat.js';
 import { createAnalyticsRouter } from '../analytics/events.js';
 import { createIntegrationsRouter } from '../integrations/devops-hub.js';
 import { getConfiguredLocalModel, probeLocalModelProvider } from './model-provider.js';
+import { isApprovalPolicyPreset } from '../config/default.js';
+import { normalizeProjectBridgeSession } from './project-session.js';
 
 export interface GatewayServer {
   httpServer: http.Server;
@@ -119,6 +123,41 @@ export function createGatewayServer(
     res.json(await probeLocalModelProvider(config));
   });
 
+  function runtimeConfigResponse(): RuntimeConfigResponse {
+    return {
+      approval_policy_preset: config.approvalPolicyPreset,
+      heartbeat_interval_ms: config.heartbeatIntervalMs,
+      require_biometric: config.requireBiometric,
+      local_model: getConfiguredLocalModel(config),
+    };
+  }
+
+  app.get('/api/config/runtime', auth, (_req: Request, res: Response) => {
+    res.json(runtimeConfigResponse());
+  });
+
+  app.patch('/api/config/runtime', auth, (req: Request, res: Response) => {
+    const body = req.body as RuntimeConfigUpdateRequest;
+
+    if (body.approval_policy_preset !== undefined) {
+      if (!isApprovalPolicyPreset(body.approval_policy_preset)) {
+        res.status(400).json({ error: { code: 4000, message: 'Invalid approval_policy_preset' } });
+        return;
+      }
+      config.approvalPolicyPreset = body.approval_policy_preset;
+    }
+
+    if (body.heartbeat_interval_ms !== undefined) {
+      if (!Number.isInteger(body.heartbeat_interval_ms) || body.heartbeat_interval_ms < 1_000 || body.heartbeat_interval_ms > 60_000) {
+        res.status(400).json({ error: { code: 4000, message: 'heartbeat_interval_ms must be an integer from 1000 to 60000' } });
+        return;
+      }
+      wsManager.updateHeartbeatInterval(body.heartbeat_interval_ms);
+    }
+
+    res.json(runtimeConfigResponse());
+  });
+
   // ── Agents ───────────────────────────────────────────────────────────────
 
   app.get('/api/agents', auth, (_req: Request, res: Response) => {
@@ -179,7 +218,7 @@ export function createGatewayServer(
   });
 
   app.post('/api/bridges/upsert', auth, async (req: Request, res: Response) => {
-    const session = await state.upsertBridgeSession(req.body);
+    const session = await state.upsertBridgeSession(normalizeProjectBridgeSession(req.body));
     res.json(session);
   });
 

--- a/openclaw-skills/src/gateway/websocket.ts
+++ b/openclaw-skills/src/gateway/websocket.ts
@@ -47,6 +47,7 @@ interface ClientSession {
 
 export interface WebSocketRuntimeSnapshot {
   connected_clients: number;
+  heartbeat_interval_ms: number;
   last_inbound_at: string | null;
   last_outbound_at: string | null;
   sessions: Array<{
@@ -75,9 +76,7 @@ export class WebSocketManager {
     this.state = state;
     this.config = config;
     this.attachStateListeners();
-    this.heartbeatTimer = setInterval(() => {
-      this.broadcastHeartbeat();
-    }, this.config.heartbeatIntervalMs);
+    this.heartbeatTimer = this.createHeartbeatTimer();
   }
 
   // ── State → Broadcast bridge ─────────────────────────────────────────────
@@ -341,6 +340,7 @@ export class WebSocketManager {
   public getRuntimeSnapshot(): WebSocketRuntimeSnapshot {
     return {
       connected_clients: this.clients.size,
+      heartbeat_interval_ms: this.config.heartbeatIntervalMs,
       last_inbound_at: this.lastInboundAt,
       last_outbound_at: this.lastOutboundAt,
       sessions: Array.from(this.clients.values()).map((session) => ({
@@ -354,6 +354,13 @@ export class WebSocketManager {
 
   public stop(): void {
     clearInterval(this.heartbeatTimer);
+  }
+
+  public updateHeartbeatInterval(intervalMs: number): void {
+    this.config.heartbeatIntervalMs = intervalMs;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = this.createHeartbeatTimer();
+    this.broadcastHeartbeat();
   }
 
   /** WebSocketServer instance (for attaching to HTTP server). */
@@ -370,6 +377,12 @@ export class WebSocketManager {
       uptime_seconds: Math.floor((Date.now() - this.startedAt) / 1000),
     };
     this.broadcastToAll('heartbeat', payload);
+  }
+
+  private createHeartbeatTimer(): ReturnType<typeof setInterval> {
+    return setInterval(() => {
+      this.broadcastHeartbeat();
+    }, this.config.heartbeatIntervalMs);
   }
 }
 

--- a/openclaw-skills/src/types/protocol.ts
+++ b/openclaw-skills/src/types/protocol.ts
@@ -202,6 +202,22 @@ export interface BridgeSession {
   metadata: Record<string, unknown>;
 }
 
+export interface RuntimeConfigResponse {
+  approval_policy_preset: string;
+  heartbeat_interval_ms: number;
+  require_biometric: boolean;
+  local_model: {
+    enabled: boolean;
+    base_url: string | null;
+    model: string | null;
+  };
+}
+
+export interface RuntimeConfigUpdateRequest {
+  approval_policy_preset?: string;
+  heartbeat_interval_ms?: number;
+}
+
 // ─── Scheduled Loops ──────────────────────────────────────────────────────────
 
 /** Schedule definition for recurring tasks. */

--- a/openclaw-skills/tests/project-session.test.ts
+++ b/openclaw-skills/tests/project-session.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from '@jest/globals';
+import { normalizeProjectBridgeSession } from '../src/gateway/project-session.js';
+import type { BridgeSession } from '../src/types/protocol.js';
+
+function bridge(overrides: Partial<BridgeSession> = {}): BridgeSession {
+  const now = new Date().toISOString();
+  return {
+    id: 'openclaw-tui',
+    agent_id: 'agent-main',
+    type: 'terminal',
+    title: 'OpenClaw TUI',
+    cwd: '/Users/test/work/repo-a',
+    closed: false,
+    created_at: now,
+    updated_at: now,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('project-scoped bridge sessions', () => {
+  test('derives stable project session id from cwd', () => {
+    const first = normalizeProjectBridgeSession(bridge());
+    const second = normalizeProjectBridgeSession(bridge({ id: 'another-global-id' }));
+
+    expect(first.id).toMatch(/^project:repo-a:[a-f0-9]{10}$/);
+    expect(second.id).toBe(first.id);
+    expect(first.metadata['original_session_id']).toBe('openclaw-tui');
+    expect(first.metadata['project_name']).toBe('repo-a');
+    expect(first.metadata['session_scope']).toBe('project');
+  });
+
+  test('uses different sessions for different projects', () => {
+    const repoA = normalizeProjectBridgeSession(bridge({ cwd: '/Users/test/work/repo-a' }));
+    const repoB = normalizeProjectBridgeSession(bridge({ cwd: '/Users/test/work/repo-b' }));
+
+    expect(repoA.id).not.toBe(repoB.id);
+    expect(repoB.metadata['project_name']).toBe('repo-b');
+  });
+});

--- a/openclaw-skills/tests/runtime-config.test.ts
+++ b/openclaw-skills/tests/runtime-config.test.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, test } from '@jest/globals';
+import DEFAULT_CONFIG from '../src/config/default.js';
+import { StateManager } from '../src/gateway/state.js';
+import { createGatewayServer, type GatewayServer } from '../src/gateway/server.js';
+import type { GatewayConfig } from '../src/config/default.js';
+
+const servers: GatewayServer[] = [];
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    await servers.pop()?.stop();
+  }
+});
+
+function tempConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    host: '127.0.0.1',
+    port: 0,
+    tokenStorePath: path.join(os.tmpdir(), `openclaw-runtime-config-${Date.now()}-${Math.random().toString(36).slice(2)}.json`),
+    loadSeedData: false,
+    simulateBridges: false,
+    ...overrides,
+  };
+}
+
+async function start(config: GatewayConfig): Promise<{ server: GatewayServer; baseUrl: string; token: string }> {
+  const server = createGatewayServer(config, new StateManager());
+  servers.push(server);
+  await server.start();
+  const address = server.httpServer.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected TCP server address');
+  }
+  const token = server.tokenManager.getDefaultDevToken();
+  if (!token) {
+    throw new Error('Expected default dev token');
+  }
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    token,
+  };
+}
+
+describe('runtime config API', () => {
+  test('updates approval policy and heartbeat interval at runtime', async () => {
+    const config = tempConfig({ approvalPolicyPreset: 'manual', heartbeatIntervalMs: 10_000 });
+    const { baseUrl, token } = await start(config);
+
+    const response = await fetch(`${baseUrl}/api/config/runtime`, {
+      method: 'PATCH',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        approval_policy_preset: 'repo-yolo',
+        heartbeat_interval_ms: 1_000,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as Record<string, unknown>;
+    expect(body['approval_policy_preset']).toBe('repo-yolo');
+    expect(body['heartbeat_interval_ms']).toBe(1_000);
+    expect(config.approvalPolicyPreset).toBe('repo-yolo');
+    expect(config.heartbeatIntervalMs).toBe(1_000);
+
+    fs.rmSync(config.tokenStorePath, { force: true });
+  });
+
+  test('rejects invalid approval presets', async () => {
+    const config = tempConfig();
+    const { baseUrl, token } = await start(config);
+
+    const response = await fetch(`${baseUrl}/api/config/runtime`, {
+      method: 'PATCH',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ approval_policy_preset: 'blind-yolo' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(config.approvalPolicyPreset).toBe(DEFAULT_CONFIG.approvalPolicyPreset);
+
+    fs.rmSync(config.tokenStorePath, { force: true });
+  });
+});


### PR DESCRIPTION
## What changed

- Adds project-scoped bridge session normalization so `openclaw tui` sessions are keyed by project root instead of reusing a machine-wide session identity.
- Adds gateway runtime config APIs for approval policy preset and heartbeat interval updates.
- Adds WebSocket heartbeat metadata and client-side activity timestamps so mobile clients can show ongoing gateway signals instead of looking idle.
- Surfaces project session metadata in bridge lists and runtime health details in gateway settings.
- Expands Dependabot auto-merge orchestration to dispatch missing required CI/security workflows instead of leaving PRs waiting on stale pending checks.

## Why

OpenClaw was hard to trust operationally because sessions could appear reused across projects, clients could sit on `connected | idle` without visible proof of life, and dependency PRs still required manual babysitting when required checks were missing.

## Validation

Verified locally:

- `npm ci` in `openclaw-skills` exited 0.
- Targeted Jest run exited 0: 5 suites passed, 38 tests passed.
- `npx tsc --noEmit` exited 0.
- `npm run lint` exited 0.
- Full `npm test` exited 0: 10 suites passed, 97 tests passed.
- `npm run build` exited 0.
- `npm audit --audit-level=high` exited 0; only low-severity transitive findings remain under the current Firebase Admin dependency chain.
- `./gradlew testDebugUnitTest --no-daemon` exited 0.
- `./gradlew assembleDebug --no-daemon` exited 0.
- Changed iOS Swift surface typechecked with `xcrun swiftc -typecheck` and exited 0.
- `git diff --check` exited 0.
- Pre-commit hook passed and created commit `44ad56ebd8474fe661dc22d44af1ed31de96f1fb`.

Not fully verified locally:

- Full `xcodebuild` did not complete because Swift Package resolution repeatedly stalled fetching `https://github.com/RevenueCat/purchases-ios.git`; the changed Swift files were typechecked directly instead.
