### PR TITLE
fix: include dashboard files in iOS project

### DIFF
--- a/ios/OpenClawConsole/OpenClawConsole.xcodeproj/project.pbxproj
+++ b/ios/OpenClawConsole/OpenClawConsole.xcodeproj/project.pbxproj
@@ -31,10 +31,13 @@
 		86E92D78B4590725F53CEF47 /* ApprovalBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE8627C1FD4D7384D0F039D /* ApprovalBannerView.swift */; };
 		8C36E210614A9D9FE9E414D7 /* IncidentListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2D4D93012B1AF15CE032EF /* IncidentListViewModel.swift */; };
 		8DD21866F6A167E9B4DA0BBC /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F9FF3A8CA3A0C5D1395632 /* NotificationService.swift */; };
+		90A7F1A2B3C4D5E601234567 /* NotificationActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A7F1A2B3C4D5E601234568 /* NotificationActionHandler.swift */; };
 		953C3B052F95CC93A8040197 /* IncidentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B37EC455A5F78045FA8EA7A /* IncidentDetailView.swift */; };
 		966ECBF0E91A054093E2D67F /* GatewayListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A371EC180F91BDFA129B9 /* GatewayListView.swift */; };
 		9F737B7808C9CD05B42D4B9B /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842FD483A26BED5A85DC4F7C /* ChatMessage.swift */; };
 		A330FCFB0BA37C7C133E62C6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CED7B8B440732222DBF270DB /* Assets.xcassets */; };
+		A7F1A2B3C4D5E60123456789 /* FleetDashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F1A2B3C4D5E6012345678A /* FleetDashboardViewModel.swift */; };
+		A7F1A2B3C4D5E6012345678B /* FleetDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F1A2B3C4D5E6012345678C /* FleetDashboardView.swift */; };
 		A493D58690FC2CE687DA91D7 /* IncidentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E2C6547FC111A0704755D8 /* IncidentListView.swift */; };
 		AC0FFC34FFACB1A930B10B57 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91ED0911899971B33856481 /* KeychainService.swift */; };
 		AFF4755AB8473B8C3FB0CD59 /* TimeAgoText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1974DC28FE46E8DE552AB153 /* TimeAgoText.swift */; };
@@ -92,6 +95,7 @@
 		CED7B8B440732222DBF270DB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D025F37633CB3007EC40F5FB /* Agent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent.swift; sourceTree = "<group>"; };
 		D2F9FF3A8CA3A0C5D1395632 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		90A7F1A2B3C4D5E601234568 /* NotificationActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationActionHandler.swift; sourceTree = "<group>"; };
 		D928179E99267A56D9E33E52 /* TaskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListView.swift; sourceTree = "<group>"; };
 		D9744F34B8396A1E8942101E /* OCTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCTask.swift; sourceTree = "<group>"; };
 		DE4072C9B69E4184E045980D /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
@@ -99,22 +103,25 @@
 		DF8869C2C89DE90325B36537 /* TaskDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailViewModel.swift; sourceTree = "<group>"; };
 		E3E2C6547FC111A0704755D8 /* IncidentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncidentListView.swift; sourceTree = "<group>"; };
 		E6FA102101C6035470CBAF55 /* SubscriptionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionView.swift; sourceTree = "<group>"; };
+		A7F1A2B3C4D5E6012345678A /* FleetDashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDashboardViewModel.swift; sourceTree = "<group>"; };
+		A7F1A2B3C4D5E6012345678C /* FleetDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDashboardView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
 		0316CDEF9ADF932B23A91237 /* Views */ = {
 			isa = PBXGroup;
-			children = (
-				3999F387613A839206EB5B56 /* ContentView.swift */,
-				C61E89ABC4C29C3008787294 /* MainTabView.swift */,
-				0B7400156998A215FDD3F85F /* Agents */,
-				2261603496B3CF0F0F6A0D1F /* Approvals */,
-				06143CA74AA11898DD6EC38A /* Chat */,
-				A6267BD60FFBC7F3FC6C08AE /* Components */,
-				B30878B13876FCA0C31050C1 /* Incidents */,
-				04C5E0146D1D1236FCF0AAB8 /* Settings */,
-				E6769E232CBDC15EDA6FD49C /* Tasks */,
-				8DA992D7EDDFC96A9CEF51A9 /* Bridges */,
+				children = (
+					3999F387613A839206EB5B56 /* ContentView.swift */,
+					C61E89ABC4C29C3008787294 /* MainTabView.swift */,
+					0B7400156998A215FDD3F85F /* Agents */,
+					2261603496B3CF0F0F6A0D1F /* Approvals */,
+					06143CA74AA11898DD6EC38A /* Chat */,
+					A6267BD60FFBC7F3FC6C08AE /* Components */,
+					A7F1A2B3C4D5E6012345678D /* Dashboard */,
+					B30878B13876FCA0C31050C1 /* Incidents */,
+					04C5E0146D1D1236FCF0AAB8 /* Settings */,
+					E6769E232CBDC15EDA6FD49C /* Tasks */,
+					8DA992D7EDDFC96A9CEF51A9 /* Bridges */,
 				B42E9C2B92515022D081DA80 /* Loops */,
 				6B5A8C82D83EB6F57C95ACB2 /* Git */,
 				E6FA102101C6035470CBAF55 /* SubscriptionView.swift */,
@@ -165,14 +172,15 @@
 			isa = PBXGroup;
 			children = (
 				16BEA5AD6F77FE5CBD437E1E /* AgentListViewModel.swift */,
-				7465BA19A6F55111388C81A8 /* ApprovalViewModel.swift */,
-				C0A9BFEF432C2C99D3AB2B64 /* GatewayManager.swift */,
-				6F2D4D93012B1AF15CE032EF /* IncidentListViewModel.swift */,
-				DF8869C2C89DE90325B36537 /* TaskDetailViewModel.swift */,
-				693C1589C4E7330AE88DCD42 /* TaskListViewModel.swift */,
-				835C9A68460CC97B756BE905 /* BridgeListViewModel.swift */,
-				9BFCE7F2EB8D7BD4E2B1FAF4 /* LoopListViewModel.swift */,
-				2541D95F19C1031C40F776B7 /* GitViewModel.swift */,
+					7465BA19A6F55111388C81A8 /* ApprovalViewModel.swift */,
+					C0A9BFEF432C2C99D3AB2B64 /* GatewayManager.swift */,
+					6F2D4D93012B1AF15CE032EF /* IncidentListViewModel.swift */,
+					DF8869C2C89DE90325B36537 /* TaskDetailViewModel.swift */,
+					693C1589C4E7330AE88DCD42 /* TaskListViewModel.swift */,
+					835C9A68460CC97B756BE905 /* BridgeListViewModel.swift */,
+					A7F1A2B3C4D5E6012345678A /* FleetDashboardViewModel.swift */,
+					9BFCE7F2EB8D7BD4E2B1FAF4 /* LoopListViewModel.swift */,
+					2541D95F19C1031C40F776B7 /* GitViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -209,17 +217,25 @@
 			path = Git;
 			sourceTree = "<group>";
 		};
-		8DA992D7EDDFC96A9CEF51A9 /* Bridges */ = {
-			isa = PBXGroup;
-			children = (
-				754FAE9E54F091902F14B761 /* BridgeListView.swift */,
-			);
-			path = Bridges;
-			sourceTree = "<group>";
-		};
-		A6267BD60FFBC7F3FC6C08AE /* Components */ = {
-			isa = PBXGroup;
-			children = (
+			8DA992D7EDDFC96A9CEF51A9 /* Bridges */ = {
+				isa = PBXGroup;
+				children = (
+					754FAE9E54F091902F14B761 /* BridgeListView.swift */,
+				);
+				path = Bridges;
+				sourceTree = "<group>";
+			};
+			A7F1A2B3C4D5E6012345678D /* Dashboard */ = {
+				isa = PBXGroup;
+				children = (
+					A7F1A2B3C4D5E6012345678C /* FleetDashboardView.swift */,
+				);
+				path = Dashboard;
+				sourceTree = "<group>";
+			};
+			A6267BD60FFBC7F3FC6C08AE /* Components */ = {
+				isa = PBXGroup;
+				children = (
 				52ACE84DE106112376EC9414 /* ResourceLinkChip.swift */,
 				8A2AD462AAE57779B0DE9F4E /* SeverityBadge.swift */,
 				ADC76505A1ACB7BAEF914F07 /* StatusDot.swift */,
@@ -255,14 +271,15 @@
 			sourceTree = "<group>";
 		};
 		F845E0B17B0AF7DD02686BF0 /* Services */ = {
-			isa = PBXGroup;
-			children = (
-				DE4072C9B69E4184E045980D /* APIService.swift */,
-				654A4451670E3B268745438C /* BiometricService.swift */,
-				C91ED0911899971B33856481 /* KeychainService.swift */,
-				D2F9FF3A8CA3A0C5D1395632 /* NotificationService.swift */,
-				84E514BCE93EB1F89A2190D0 /* WebSocketService.swift */,
-				2EA61FDED4CB7C7C23A65793 /* SubscriptionService.swift */,
+				isa = PBXGroup;
+				children = (
+					DE4072C9B69E4184E045980D /* APIService.swift */,
+					654A4451670E3B268745438C /* BiometricService.swift */,
+					C91ED0911899971B33856481 /* KeychainService.swift */,
+					90A7F1A2B3C4D5E601234568 /* NotificationActionHandler.swift */,
+					D2F9FF3A8CA3A0C5D1395632 /* NotificationService.swift */,
+					84E514BCE93EB1F89A2190D0 /* WebSocketService.swift */,
+					2EA61FDED4CB7C7C23A65793 /* SubscriptionService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -390,6 +407,7 @@
 				8C36E210614A9D9FE9E414D7 /* IncidentListViewModel.swift in Sources */,
 				AC0FFC34FFACB1A930B10B57 /* KeychainService.swift in Sources */,
 				0802C43B4A799C06A1462B3F /* MainTabView.swift in Sources */,
+				90A7F1A2B3C4D5E601234567 /* NotificationActionHandler.swift in Sources */,
 				8DD21866F6A167E9B4DA0BBC /* NotificationService.swift in Sources */,
 				C66D3143C15269ECE9DC33E1 /* OCTask.swift in Sources */,
 				583576DE1E6079CE1FDF374D /* OpenClawConsoleApp.swift in Sources */,
@@ -404,6 +422,8 @@
 				4A71CA2536F12EF85385EA67 /* WebSocketMessage.swift in Sources */,
 				1411E663C8A4209F050783A9 /* WebSocketService.swift in Sources */,
 				315237B0AC0885BA95872322 /* BridgeListViewModel.swift in Sources */,
+				A7F1A2B3C4D5E6012345678B /* FleetDashboardView.swift in Sources */,
+				A7F1A2B3C4D5E60123456789 /* FleetDashboardViewModel.swift in Sources */,
 				C5CEBE64263B8C9C3A14ABA4 /* LoopListViewModel.swift in Sources */,
 				7AF104557BE694319D4C69E7 /* GitViewModel.swift in Sources */,
 				7DD46EB04BBC5FACB451F902 /* BridgeListView.swift in Sources */,


### PR DESCRIPTION
## Summary
- add the new dashboard view, dashboard view model, and notification action handler to the iOS Xcode project
- fix the post-merge iOS CI path from #211 where files existed on disk but were not part of the app target

## Verification
- git diff --check
- plutil -lint ios/OpenClawConsole/OpenClawConsole.xcodeproj/project.pbxproj
- all Swift source basenames under ios/OpenClawConsole/OpenClawConsole are referenced by project.pbxproj
- xcrun swiftc -typecheck for app Swift files excluding the unresolved RevenueCat package boundary exited 0 (warnings only)

## Notes
- Full local xcodebuild did not complete because Xcode package resolution hung while fetching RevenueCat; this PR relies on GitHub Actions for final Xcode build proof.