### PR TITLE
fix: finalize closed PR state status

### DIFF
--- a/.github/workflows/pr-state-machine.yml
+++ b/.github/workflows/pr-state-machine.yml
@@ -2,7 +2,7 @@ name: PR State Machine
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, closed]
   check_suite:
     types: [completed]
   workflow_dispatch:
@@ -414,10 +414,28 @@ jobs:
               })).data;
 
               if (pr.state !== "open") {
-                core.info(`Skipping PR #${prNumber}: state is ${pr.state}`);
+                const finalDescription = pr.merged
+                  ? "PR merged; required checks passed."
+                  : "PR closed; state machine inactive.";
+                await github.rest.repos.createCommitStatus({
+                  owner,
+                  repo,
+                  sha: pr.head.sha,
+                  state: "success",
+                  context: "pr/state-machine",
+                  description: finalDescription,
+                  target_url: runUrl
+                });
+
+                if (pr.merged) {
+                  await setStateLabel(prNumber, "pr-state:ci_green");
+                }
+
+                core.info(`Finalized PR #${prNumber}: state=${pr.state}, merged=${pr.merged}`);
                 return {
                   prNumber,
-                  skipped: true
+                  finalized: true,
+                  merged: pr.merged
                 };
               }
 


### PR DESCRIPTION
## Summary
- run the PR state machine on closed PR events
- write a terminal success status for merged/closed PRs so stale pending `pr/state-machine` statuses do not remain after merge

## Verification
- ruby YAML parse: `YAML.load_file('.github/workflows/pr-state-machine.yml')`
- `git diff --check`
- pre-commit hook passed