### PR TITLE
feat+fix(mobile): Android paywall + distribution auth

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -73,14 +73,13 @@ jobs:
         env:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
           set -euo pipefail
-          for name in MATCH_GIT_URL MATCH_PASSWORD MATCH_GIT_BASIC_AUTHORIZATION APPSTORE_PRIVATE_KEY APPSTORE_KEY_ID APPSTORE_ISSUER_ID ADMIN_TOKEN; do
+          for name in MATCH_GIT_URL MATCH_PASSWORD APPSTORE_PRIVATE_KEY APPSTORE_KEY_ID APPSTORE_ISSUER_ID ADMIN_TOKEN; do
             if [ -z "${!name:-}" ]; then
               echo "❌ Missing required secret: $name"
               exit 1
@@ -121,6 +120,11 @@ jobs:
         run: |
           set -euo pipefail
           git config --global url."https://x-access-token:${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"
+          # Derive MATCH_GIT_BASIC_AUTHORIZATION from ADMIN_TOKEN to avoid stale credential issues.
+          # Fastlane match uses this header to authenticate git clone of the certificates repo.
+          MATCH_AUTH=$(printf 'x-access-token:%s' "$GIT_AUTH_TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$MATCH_AUTH"
+          echo "MATCH_GIT_BASIC_AUTHORIZATION=$MATCH_AUTH" >> "$GITHUB_ENV"
 
       - name: Setup signing certificates and profiles (match)
         env:
@@ -129,7 +133,6 @@ jobs:
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: bundle exec fastlane setup
         working-directory: ios/OpenClawConsole
 
@@ -142,7 +145,6 @@ jobs:
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: bundle exec fastlane beta
         working-directory: ios/OpenClawConsole
 
@@ -312,17 +314,35 @@ jobs:
           FIREBASE_INTERNAL_GROUPS: ${{ vars.FIREBASE_INTERNAL_GROUPS }}
           FIREBASE_REQUIRED_TESTER_EMAIL: ${{ vars.FIREBASE_REQUIRED_TESTER_EMAIL }}
           FIREBASE_APP_ID: ${{ steps.firebase.outputs.app_id }}
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || 'openclaw-console-mobile' }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
         run: |
           set -Eeuo pipefail
           trap 'rc=$?; echo "❌ Firebase distribution failed at line $LINENO: $BASH_COMMAND (rc=$rc)"; exit $rc' ERR
 
           # Validate Firebase project configuration
-          echo "🔍 Pre-flight Firebase project verification"
-          # Validate Firebase project exists in accessible projects list
-          if ! firebase projects:list --json | jq -e '.result[] | select(.projectId == "openclaw-console-mobile")' > /dev/null; then
-            echo "❌ Firebase project openclaw-console-mobile not accessible or does not exist"
-            exit 1
+          echo "🔍 Pre-flight Firebase project verification (project=$FIREBASE_PROJECT_ID)"
+          # Extract project ID from google-services.json as authoritative source when secret unset
+          RESOLVED_PROJECT_ID="${FIREBASE_PROJECT_ID}"
+          if [ -z "$RESOLVED_PROJECT_ID" ] || [ "$RESOLVED_PROJECT_ID" = "openclaw-console-mobile" ]; then
+            GS_PROJECT_ID="$(jq -r '.project_info.project_id // empty' android/app/google-services.json 2>/dev/null || true)"
+            if [ -n "$GS_PROJECT_ID" ]; then
+              echo "ℹ️ Resolving Firebase project ID from google-services.json: $GS_PROJECT_ID"
+              RESOLVED_PROJECT_ID="$GS_PROJECT_ID"
+            fi
+          fi
+          export FIREBASE_PROJECT_ID="$RESOLVED_PROJECT_ID"
+          echo "FIREBASE_PROJECT_ID=$FIREBASE_PROJECT_ID" >> "$GITHUB_ENV"
+
+          # Validate Firebase project exists in accessible projects list (soft check — some
+          # service accounts only have app-distribution role and cannot list projects).
+          if firebase projects:list --json > /tmp/fb-projects.json 2>/dev/null; then
+            if ! jq -e --arg pid "$FIREBASE_PROJECT_ID" '.result[] | select(.projectId == $pid)' /tmp/fb-projects.json > /dev/null; then
+              echo "⚠️ Project $FIREBASE_PROJECT_ID not visible to this credential; continuing anyway (distribute will fail if truly inaccessible)"
+            else
+              echo "✅ Firebase project $FIREBASE_PROJECT_ID accessible"
+            fi
+          else
+            echo "ℹ️ Could not list Firebase projects (credential may lack projects.get); continuing to distribute attempt"
           fi
 
           # Validate package name matches Firebase app
@@ -334,11 +354,12 @@ jobs:
           fi
 
           # Determine authentication method with explicit precedence
+          # IMPORTANT: Do NOT unset FIREBASE_TOKEN when using service account — we keep it
+          # around so the retry loop below can fall back to token auth if the service
+          # account lacks the required roles (firebaseappdistro.admin).
           AUTH_MODE=""
           if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] && [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
             AUTH_MODE="service_account"
-            # Clear deprecated token to prevent confusion
-            unset FIREBASE_TOKEN
             echo "✅ Using service account authentication (2026 best practice)"
           elif [ -n "${FIREBASE_TOKEN:-}" ]; then
             AUTH_MODE="deprecated_token"
@@ -435,7 +456,7 @@ jobs:
       - name: Verify Firebase distribution actually worked
         env:
           FIREBASE_APP_ID: ${{ steps.firebase.outputs.app_id }}
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || 'openclaw-console-mobile' }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -87,9 +87,8 @@ jobs:
         working-directory: ios/OpenClawConsole
         run: |
           set -euo pipefail
-          if [ ! -f "OpenClawConsole.xcodeproj/project.pbxproj" ]; then
-            xcodegen generate
-          fi
+          # Always regenerate project to ensure all source files are included
+          xcodegen generate
           test -f "OpenClawConsole.xcodeproj/project.pbxproj"
 
       - name: Install Fastlane

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -21,6 +21,14 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        // RevenueCat public key. CI injects REVENUECAT_PUBLIC_KEY at build time;
+        // local builds without the secret fall through to empty string, which
+        // SubscriptionService.configure treats as "disabled".
+        val revenueCatKey = System.getenv("REVENUECAT_PUBLIC_KEY")
+            ?: providers.gradleProperty("revenueCatPublicKey").orNull
+            ?: ""
+        buildConfigField("String", "REVENUECAT_PUBLIC_KEY", "\"$revenueCatKey\"")
     }
 
     signingConfigs {
@@ -61,6 +69,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     lint {
@@ -127,6 +136,10 @@ dependencies {
 
     // Pull-to-refresh
     implementation("androidx.compose.material:material:1.6.0")
+
+    // RevenueCat (Android billing + subscription management).
+    // Mirrors iOS SubscriptionService — product IDs and entitlement name must match iOS.
+    implementation("com.revenuecat.purchases:purchases:9.29.1")
 
     // Test
     testImplementation("junit:junit:4.13.2")

--- a/android/app/src/main/java/com/openclaw/console/OpenClawApplication.kt
+++ b/android/app/src/main/java/com/openclaw/console/OpenClawApplication.kt
@@ -2,12 +2,13 @@ package com.openclaw.console
 
 import android.app.Application
 import android.util.Log
+import com.openclaw.console.service.subscription.SubscriptionService
 
 /**
  * OpenClaw Console Application class
  *
  * Handles app-wide initialization including:
- * - Global services setup
+ * - Subscription service (RevenueCat) configuration
  */
 class OpenClawApplication : Application() {
 
@@ -18,5 +19,12 @@ class OpenClawApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         Log.i(TAG, "OpenClaw Console starting...")
+
+        // Configure RevenueCat. The key is baked in via BuildConfig at build time
+        // (set in CI from the REVENUECAT_PUBLIC_KEY secret). When the key is blank
+        // (e.g. local debug builds without the secret), SubscriptionService.configure
+        // no-ops and the paywall UI shows a "not configured" notice.
+        val key = BuildConfig.REVENUECAT_PUBLIC_KEY
+        SubscriptionService.getInstance(this).configure(apiKey = key)
     }
 }

--- a/android/app/src/main/java/com/openclaw/console/service/subscription/SubscriptionModels.kt
+++ b/android/app/src/main/java/com/openclaw/console/service/subscription/SubscriptionModels.kt
@@ -1,0 +1,54 @@
+package com.openclaw.console.service.subscription
+
+/**
+ * Subscription tiers supported by OpenClaw Console.
+ * Mirror of iOS `SubscriptionTier` — values MUST match so analytics/billing join across platforms.
+ */
+enum class SubscriptionTier(val raw: String, val displayName: String) {
+    FREE("free", "Free"),
+    PRO_MONTHLY("pro_monthly", "Pro Monthly"),
+    PRO_YEARLY("pro_yearly", "Pro Yearly");
+
+    companion object {
+        fun fromProductId(productId: String?): SubscriptionTier = when {
+            productId == null -> FREE
+            productId.contains("yearly", ignoreCase = true) -> PRO_YEARLY
+            productId.contains("monthly", ignoreCase = true) -> PRO_MONTHLY
+            else -> FREE
+        }
+    }
+}
+
+/**
+ * Current subscription snapshot. All fields are nullable/sane-default so downstream UI
+ * can render without null checks.
+ */
+data class SubscriptionStatus(
+    val tier: SubscriptionTier = SubscriptionTier.FREE,
+    val isActive: Boolean = false,
+    val willRenew: Boolean = false,
+    val expirationDateMillis: Long? = null,
+    val productIdentifier: String? = null,
+    val hasProEntitlement: Boolean = false
+)
+
+/**
+ * Result type returned from purchase/restore flows. Mirrors iOS PurchaseResult.
+ */
+sealed class PurchaseResult {
+    object Success : PurchaseResult()
+    object UserCancelled : PurchaseResult()
+    data class Error(val message: String) : PurchaseResult()
+}
+
+/**
+ * Offering package surfaced to the paywall. We only expose what the UI needs —
+ * title, price string (already localized by Play Billing), billing period hint.
+ */
+data class SubscriptionPackage(
+    val productId: String,
+    val title: String,
+    val priceString: String,
+    val periodDescription: String,
+    val isYearly: Boolean
+)

--- a/android/app/src/main/java/com/openclaw/console/service/subscription/SubscriptionService.kt
+++ b/android/app/src/main/java/com/openclaw/console/service/subscription/SubscriptionService.kt
@@ -1,0 +1,248 @@
+package com.openclaw.console.service.subscription
+
+import android.app.Activity
+import android.content.Context
+import android.util.Log
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.LogLevel
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PurchasesConfiguration
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.interfaces.PurchaseCallback
+import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
+import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
+import com.revenuecat.purchases.models.StoreTransaction
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * RevenueCat-backed subscription service for Android. Mirrors the iOS
+ * [ios/.../SubscriptionService.swift] contract — same product IDs, same `pro` entitlement,
+ * same status model — so a user's Pro access is portable across platforms.
+ *
+ * Usage:
+ * 1. Call [configure] once at app start (from Application.onCreate) with the Play-Store
+ *    RevenueCat public key (build-time config).
+ * 2. Observe [status] as a StateFlow for UI binding.
+ * 3. Call [loadOfferings] to populate paywall, [purchase] to buy, [restore] to restore.
+ */
+class SubscriptionService private constructor(private val appContext: Context) {
+
+    companion object {
+        private const val TAG = "SubscriptionService"
+
+        /** Entitlement ID configured in RevenueCat dashboard. MUST match iOS. */
+        const val PRO_ENTITLEMENT_ID = "pro"
+        const val PRO_MONTHLY_PRODUCT_ID = "com.openclaw.console.pro.monthly"
+        const val PRO_YEARLY_PRODUCT_ID = "com.openclaw.console.pro.yearly"
+
+        @Volatile
+        private var INSTANCE: SubscriptionService? = null
+
+        fun getInstance(context: Context): SubscriptionService =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: SubscriptionService(context.applicationContext).also { INSTANCE = it }
+            }
+    }
+
+    private val _status = MutableStateFlow(SubscriptionStatus())
+    val status: StateFlow<SubscriptionStatus> = _status.asStateFlow()
+
+    private val _offerings = MutableStateFlow<List<SubscriptionPackage>>(emptyList())
+    val offerings: StateFlow<List<SubscriptionPackage>> = _offerings.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    /** Raw RevenueCat packages, kept for [purchase]. Maps productId -> Package. */
+    private var packageCache: Map<String, Package> = emptyMap()
+
+    private var configured = false
+
+    /**
+     * Idempotent initialization. Safe to call from Application.onCreate before the API
+     * key is known — pass an empty string to no-op.
+     */
+    fun configure(apiKey: String, appUserId: String? = null) {
+        if (apiKey.isBlank()) {
+            Log.w(TAG, "Skipping RevenueCat configure: apiKey is blank (paywall will be disabled)")
+            return
+        }
+        if (configured) {
+            Log.d(TAG, "RevenueCat already configured; skipping")
+            return
+        }
+
+        Purchases.logLevel = LogLevel.INFO
+        val config = PurchasesConfiguration.Builder(appContext, apiKey)
+            .apply { if (!appUserId.isNullOrBlank()) appUserID(appUserId) }
+            .build()
+        Purchases.configure(config)
+        configured = true
+        Log.i(TAG, "RevenueCat configured")
+
+        refreshCustomerInfo()
+    }
+
+    /** True iff [configure] was called with a valid key. */
+    fun isConfigured(): Boolean = configured
+
+    /** Pull the latest entitlement state from RevenueCat and update [status]. */
+    fun refreshCustomerInfo() {
+        if (!configured) return
+        Purchases.sharedInstance.getCustomerInfo(object : ReceiveCustomerInfoCallback {
+            override fun onReceived(customerInfo: CustomerInfo) {
+                applyCustomerInfo(customerInfo)
+            }
+
+            override fun onError(error: PurchasesError) {
+                Log.w(TAG, "refreshCustomerInfo failed: ${error.message}")
+            }
+        })
+    }
+
+    /** Suspend variant of [loadOfferings] so paywall screens can await the result. */
+    suspend fun loadOfferings(): List<SubscriptionPackage> {
+        if (!configured) return emptyList()
+        _isLoading.value = true
+        return try {
+            val offerings = fetchOfferings() ?: return emptyList()
+            val current = offerings.current ?: return emptyList()
+
+            val mapped = mutableMapOf<String, Package>()
+            val exposed = mutableListOf<SubscriptionPackage>()
+
+            current.availablePackages.forEach { pkg ->
+                val productId = pkg.product.id
+                mapped[productId] = pkg
+                val isYearly = productId.contains("yearly", ignoreCase = true) ||
+                    pkg == current.annual
+                exposed += SubscriptionPackage(
+                    productId = productId,
+                    title = pkg.product.title.ifBlank { if (isYearly) "Yearly" else "Monthly" },
+                    priceString = pkg.product.price.formatted,
+                    periodDescription = if (isYearly) "per year" else "per month",
+                    isYearly = isYearly
+                )
+            }
+
+            packageCache = mapped
+            _offerings.value = exposed
+            exposed
+        } finally {
+            _isLoading.value = false
+        }
+    }
+
+    /**
+     * Kick off the Play Billing purchase flow for the given product ID.
+     * Must be called with a real Activity context (Play Billing requires it).
+     */
+    suspend fun purchase(activity: Activity, productId: String): PurchaseResult {
+        if (!configured) return PurchaseResult.Error("Subscriptions not configured")
+        val pkg = packageCache[productId]
+            ?: return PurchaseResult.Error("Package $productId not available — try reloading offerings")
+
+        _isLoading.value = true
+        return try {
+            suspendCancellableCoroutine { cont ->
+                Purchases.sharedInstance.purchase(
+                    com.revenuecat.purchases.PurchaseParams.Builder(activity, pkg).build(),
+                    object : PurchaseCallback {
+                        override fun onCompleted(storeTransaction: StoreTransaction, customerInfo: CustomerInfo) {
+                            applyCustomerInfo(customerInfo)
+                            cont.resume(PurchaseResult.Success)
+                        }
+
+                        override fun onError(error: PurchasesError, userCancelled: Boolean) {
+                            if (userCancelled || error.code == PurchasesErrorCode.PurchaseCancelledError) {
+                                cont.resume(PurchaseResult.UserCancelled)
+                            } else {
+                                Log.w(TAG, "Purchase failed: ${error.message}")
+                                cont.resume(PurchaseResult.Error(error.message))
+                            }
+                        }
+                    }
+                )
+            }
+        } finally {
+            _isLoading.value = false
+        }
+    }
+
+    suspend fun restore(): PurchaseResult {
+        if (!configured) return PurchaseResult.Error("Subscriptions not configured")
+        _isLoading.value = true
+        return try {
+            suspendCancellableCoroutine { cont ->
+                Purchases.sharedInstance.restorePurchases(object : ReceiveCustomerInfoCallback {
+                    override fun onReceived(customerInfo: CustomerInfo) {
+                        applyCustomerInfo(customerInfo)
+                        cont.resume(PurchaseResult.Success)
+                    }
+
+                    override fun onError(error: PurchasesError) {
+                        Log.w(TAG, "Restore failed: ${error.message}")
+                        cont.resume(PurchaseResult.Error(error.message))
+                    }
+                })
+            }
+        } finally {
+            _isLoading.value = false
+        }
+    }
+
+    /**
+     * Feature-gate check. Mirrors iOS `checkProFeatureAccess(feature:)` — keep the
+     * feature string catalog in sync across platforms.
+     */
+    fun hasAccess(feature: String): Boolean {
+        val hasPro = _status.value.hasProEntitlement
+        return when (feature) {
+            "basic_approvals", "agent_monitoring", "simple_notifications" -> true
+            "devops_integrations", "advanced_analytics", "custom_webhooks",
+            "priority_support", "unlimited_agents" -> hasPro
+            else -> true
+        }
+    }
+
+    // region Internal helpers
+
+    private suspend fun fetchOfferings(): Offerings? = suspendCancellableCoroutine { cont ->
+        Purchases.sharedInstance.getOfferings(object : ReceiveOfferingsCallback {
+            override fun onReceived(offerings: Offerings) {
+                cont.resume(offerings)
+            }
+
+            override fun onError(error: PurchasesError) {
+                Log.w(TAG, "getOfferings failed: ${error.message}")
+                cont.resume(null)
+            }
+        })
+    }
+
+    private fun applyCustomerInfo(info: CustomerInfo) {
+        val entitlement = info.entitlements[PRO_ENTITLEMENT_ID]
+        val hasPro = entitlement?.isActive == true
+        val productId = entitlement?.productIdentifier
+        val tier = if (hasPro) SubscriptionTier.fromProductId(productId) else SubscriptionTier.FREE
+
+        _status.value = SubscriptionStatus(
+            tier = tier,
+            isActive = info.activeSubscriptions.isNotEmpty(),
+            willRenew = entitlement?.willRenew == true,
+            expirationDateMillis = entitlement?.expirationDate?.time,
+            productIdentifier = productId,
+            hasProEntitlement = hasPro
+        )
+        Log.d(TAG, "Subscription status updated: tier=$tier active=$hasPro")
+    }
+
+    // endregion
+}

--- a/android/app/src/main/java/com/openclaw/console/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/navigation/NavGraph.kt
@@ -29,6 +29,7 @@ import com.openclaw.console.ui.screens.incidents.IncidentDetailScreen
 import com.openclaw.console.ui.screens.incidents.IncidentListScreen
 import com.openclaw.console.ui.screens.settings.AddGatewayScreen
 import com.openclaw.console.ui.screens.settings.SettingsScreen
+import com.openclaw.console.ui.screens.subscription.PaywallScreen
 import com.openclaw.console.ui.screens.tasks.TaskDetailScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
@@ -55,6 +56,10 @@ sealed class Screen(val route: String, val label: String) {
         fun route(approvalId: String) = "approvals/$approvalId"
     }
     object AddGateway : Screen("settings/add", "Add Gateway")
+    object Paywall : Screen("paywall?feature={feature}", "Upgrade to Pro") {
+        fun route(feature: String? = null): String =
+            if (feature.isNullOrBlank()) "paywall?feature=" else "paywall?feature=$feature"
+    }
 }
 
 private data class BottomNavItem(
@@ -220,6 +225,9 @@ fun NavGraph(appViewModel: AppViewModel = viewModel()) {
                     },
                     onApprovalClick = { approvalId ->
                         navController.navigate(Screen.ApprovalDetail.route(approvalId))
+                    },
+                    onUpgradeClick = {
+                        navController.navigate(Screen.Paywall.route())
                     }
                 )
             }
@@ -240,6 +248,24 @@ fun NavGraph(appViewModel: AppViewModel = viewModel()) {
                     approvalId = approvalId,
                     appViewModel = appViewModel,
                     onBack = { navController.navigateUp() }
+                )
+            }
+
+            // Paywall — opened from Settings "Upgrade" CTA and from feature gates
+            composable(
+                route = Screen.Paywall.route,
+                arguments = listOf(
+                    navArgument("feature") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    }
+                )
+            ) { backStackEntry ->
+                val feature = backStackEntry.arguments?.getString("feature")?.ifBlank { null }
+                PaywallScreen(
+                    onClose = { navController.navigateUp() },
+                    requiredFeature = feature
                 )
             }
         }

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/settings/SettingsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
@@ -27,6 +28,7 @@ fun SettingsScreen(
     appViewModel: AppViewModel,
     onAddGateway: () -> Unit,
     onApprovalClick: (String) -> Unit,
+    onUpgradeClick: () -> Unit = {},
     viewModel: SettingsViewModel = viewModel()
 ) {
     val gatewayRepo = appViewModel.gatewayRepository
@@ -71,6 +73,11 @@ fun SettingsScreen(
                     lastSignalAt = lastGatewaySignal,
                     signalSummary = gatewaySignalSummary
                 )
+            }
+
+            // Upgrade to Pro CTA
+            item {
+                UpgradeToProCard(onClick = onUpgradeClick)
             }
 
             // Pending approvals section
@@ -219,6 +226,50 @@ private fun SwipeToDismissGatewayItem(
             isActive = isActive,
             onSetActive = onSetActive
         )
+    }
+}
+
+@Composable
+private fun UpgradeToProCard(onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Star,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Upgrade to OpenClaw Pro",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                Text(
+                    text = "DevOps integrations, advanced analytics, unlimited agents, and more.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        }
     }
 }
 

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/subscription/PaywallScreen.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/subscription/PaywallScreen.kt
@@ -1,0 +1,380 @@
+package com.openclaw.console.ui.screens.subscription
+
+import android.app.Activity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.openclaw.console.service.subscription.SubscriptionService
+
+/**
+ * Full paywall / subscription-management screen.
+ *
+ * Behaviour:
+ * - If the user already has `pro` entitlement, shows a status + restore panel.
+ * - Otherwise, lists monthly + yearly offerings with Subscribe CTAs.
+ * - Surfaces errors in a banner.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PaywallScreen(
+    onClose: () -> Unit,
+    requiredFeature: String? = null,
+    viewModel: SubscriptionViewModel = viewModel(
+        factory = SubscriptionViewModel.factory(
+            SubscriptionService.getInstance(LocalContext.current.applicationContext)
+        )
+    )
+) {
+    val status by viewModel.status.collectAsStateWithLifecycle()
+    val offerings by viewModel.offerings.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val errorMessage by viewModel.errorMessage.collectAsStateWithLifecycle()
+    val justPurchased by viewModel.justPurchased.collectAsStateWithLifecycle()
+    val activity = LocalContextUtils.currentActivity()
+
+    // Load offerings when screen first appears
+    LaunchedEffect(Unit) {
+        if (viewModel.isConfigured) {
+            viewModel.loadOfferings()
+        }
+    }
+
+    // Auto-dismiss after successful purchase/restore
+    LaunchedEffect(justPurchased) {
+        if (justPurchased) {
+            viewModel.clearJustPurchased()
+            onClose()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(if (status.hasProEntitlement) "Subscription" else "Upgrade to Pro")
+                },
+                actions = {
+                    TextButton(onClick = onClose) { Text("Close") }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            if (!viewModel.isConfigured) {
+                ConfigurationMissingNotice()
+                return@Column
+            }
+
+            HeaderSection(requiredFeature = requiredFeature, hasPro = status.hasProEntitlement)
+
+            if (errorMessage != null) {
+                ErrorBanner(message = errorMessage!!, onDismiss = viewModel::clearError)
+            }
+
+            if (status.hasProEntitlement) {
+                ProStatusCard(status)
+            } else {
+                FeatureComparison()
+                OfferingsList(
+                    offerings = offerings,
+                    isLoading = isLoading,
+                    onPurchase = { productId ->
+                        if (activity != null) {
+                            viewModel.purchase(activity, productId)
+                        }
+                    }
+                )
+            }
+
+            RestoreSection(onRestore = viewModel::restore, isLoading = isLoading)
+
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun HeaderSection(requiredFeature: String?, hasPro: Boolean) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth().padding(top = 16.dp)
+    ) {
+        Icon(
+            imageVector = if (hasPro) Icons.Default.CheckCircle else Icons.Default.Lock,
+            contentDescription = null,
+            tint = if (hasPro) MaterialTheme.colorScheme.primary else Color(0xFFEF6C00),
+            modifier = Modifier.size(48.dp)
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = if (hasPro) "OpenClaw Pro is active" else "Unlock OpenClaw Pro",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+        if (!hasPro) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = requiredFeature?.let {
+                    "This feature ($it) requires Pro"
+                } ?: "Professional-grade agent control for your pocket",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProStatusCard(status: com.openclaw.console.service.subscription.SubscriptionStatus) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer
+        )
+    ) {
+        Column(Modifier.padding(20.dp)) {
+            Text(
+                text = status.tier.displayName,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(Modifier.height(8.dp))
+            if (status.expirationDateMillis != null) {
+                val dateStr = java.text.DateFormat.getDateInstance().format(status.expirationDateMillis)
+                Text(
+                    text = if (status.willRenew) "Renews on $dateStr" else "Expires on $dateStr",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeatureComparison() {
+    val features = remember {
+        listOf(
+            FeatureRow("Basic agent monitoring", free = true, pro = true),
+            FeatureRow("Simple notifications", free = true, pro = true),
+            FeatureRow("Biometric approvals", free = true, pro = true),
+            FeatureRow("DevOps integrations", free = false, pro = true),
+            FeatureRow("Advanced analytics", free = false, pro = true),
+            FeatureRow("Custom webhooks", free = false, pro = true),
+            FeatureRow("Unlimited agents", free = false, pro = true),
+            FeatureRow("Priority support", free = false, pro = true),
+        )
+    }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Row {
+                Text("Feature", modifier = Modifier.weight(1f), fontWeight = FontWeight.Medium)
+                Text("Free", modifier = Modifier.width(56.dp), fontWeight = FontWeight.Medium, textAlign = TextAlign.Center)
+                Text("Pro", modifier = Modifier.width(56.dp), fontWeight = FontWeight.Medium, textAlign = TextAlign.Center)
+            }
+            HorizontalDivider(Modifier.padding(vertical = 8.dp))
+            features.forEach { feat ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(feat.name, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+                    Text(if (feat.free) "✓" else "—", modifier = Modifier.width(56.dp), textAlign = TextAlign.Center)
+                    Text(if (feat.pro) "✓" else "—", modifier = Modifier.width(56.dp), textAlign = TextAlign.Center)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun OfferingsList(
+    offerings: List<com.openclaw.console.service.subscription.SubscriptionPackage>,
+    isLoading: Boolean,
+    onPurchase: (String) -> Unit
+) {
+    if (isLoading && offerings.isEmpty()) {
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxWidth().padding(32.dp)
+        ) { CircularProgressIndicator() }
+        return
+    }
+    if (offerings.isEmpty()) {
+        Text(
+            "Subscription packages unavailable. Please check your connection and try again.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        return
+    }
+
+    Text(
+        "Choose your plan",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold
+    )
+
+    offerings.sortedBy { !it.isYearly }.forEach { pkg ->
+        OfferingCard(pkg = pkg, onPurchase = onPurchase, isLoading = isLoading)
+    }
+}
+
+@Composable
+private fun OfferingCard(
+    pkg: com.openclaw.console.service.subscription.SubscriptionPackage,
+    onPurchase: (String) -> Unit,
+    isLoading: Boolean
+) {
+    val isRecommended = pkg.isYearly
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isRecommended) MaterialTheme.colorScheme.primaryContainer
+                            else MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            Modifier.padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (isRecommended) {
+                Surface(
+                    color = MaterialTheme.colorScheme.primary,
+                    shape = RoundedCornerShape(6.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                    ) {
+                        Icon(Icons.Default.Star, contentDescription = null, tint = Color.White, modifier = Modifier.size(14.dp))
+                        Spacer(Modifier.width(4.dp))
+                        Text("BEST VALUE", color = Color.White, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+            Text(pkg.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(pkg.priceString, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+            Text(pkg.periodDescription, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(12.dp))
+            Button(
+                onClick = { onPurchase(pkg.productId) },
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = Color.White)
+                } else {
+                    Text("Subscribe")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RestoreSection(onRestore: () -> Unit, isLoading: Boolean) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        TextButton(onClick = onRestore, enabled = !isLoading) {
+            Text("Restore purchases")
+        }
+        Text(
+            "Already subscribed on another device? Restore here.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun ErrorBanner(message: String, onDismiss: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp)),
+        color = MaterialTheme.colorScheme.errorContainer
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                message,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f)
+            )
+            TextButton(onClick = onDismiss) { Text("Dismiss") }
+        }
+    }
+}
+
+@Composable
+private fun ConfigurationMissingNotice() {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(Modifier.padding(20.dp)) {
+            Text(
+                "Subscriptions are not configured for this build.",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "A RevenueCat API key must be supplied at build time to enable in-app purchases.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private data class FeatureRow(val name: String, val free: Boolean, val pro: Boolean)
+
+/**
+ * Helper object to find the nearest Activity from a Compose scope. Placed in the same file
+ * so we do not leak Android context utilities elsewhere.
+ */
+private object LocalContextUtils {
+    @Composable
+    fun currentActivity(): Activity? {
+        val ctx = LocalContext.current
+        var c: android.content.Context? = ctx
+        while (c is android.content.ContextWrapper) {
+            if (c is Activity) return c
+            c = c.baseContext
+        }
+        return null
+    }
+}

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/subscription/PaywallScreen.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/subscription/PaywallScreen.kt
@@ -92,8 +92,8 @@ fun PaywallScreen(
 
             HeaderSection(requiredFeature = requiredFeature, hasPro = status.hasProEntitlement)
 
-            if (errorMessage != null) {
-                ErrorBanner(message = errorMessage!!, onDismiss = viewModel::clearError)
+            errorMessage?.let { msg ->
+                ErrorBanner(message = msg, onDismiss = viewModel::clearError)
             }
 
             if (status.hasProEntitlement) {

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/subscription/SubscriptionViewModel.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/subscription/SubscriptionViewModel.kt
@@ -1,0 +1,81 @@
+package com.openclaw.console.ui.screens.subscription
+
+import android.app.Activity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.openclaw.console.service.subscription.PurchaseResult
+import com.openclaw.console.service.subscription.SubscriptionPackage
+import com.openclaw.console.service.subscription.SubscriptionService
+import com.openclaw.console.service.subscription.SubscriptionStatus
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Drives the paywall and subscription-management UI. Owns transient UI state
+ * (error banners, "just purchased" toasts). Reads the canonical subscription
+ * state from [SubscriptionService.status] directly in the Composable.
+ *
+ * The [SubscriptionService] is injected via the [factory] so the ViewModel
+ * stays decoupled from the Android framework and is unit-testable.
+ */
+class SubscriptionViewModel(
+    private val service: SubscriptionService
+) : ViewModel() {
+
+    val status: StateFlow<SubscriptionStatus> = service.status
+    val offerings: StateFlow<List<SubscriptionPackage>> = service.offerings
+    val isLoading: StateFlow<Boolean> = service.isLoading
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    private val _justPurchased = MutableStateFlow(false)
+    val justPurchased: StateFlow<Boolean> = _justPurchased.asStateFlow()
+
+    val isConfigured: Boolean get() = service.isConfigured()
+
+    fun loadOfferings() {
+        viewModelScope.launch {
+            service.loadOfferings()
+        }
+    }
+
+    fun purchase(activity: Activity, productId: String) {
+        viewModelScope.launch {
+            when (val result = service.purchase(activity, productId)) {
+                is PurchaseResult.Success -> _justPurchased.value = true
+                is PurchaseResult.UserCancelled -> Unit
+                is PurchaseResult.Error -> _errorMessage.value = result.message
+            }
+        }
+    }
+
+    fun restore() {
+        viewModelScope.launch {
+            when (val result = service.restore()) {
+                is PurchaseResult.Success -> _justPurchased.value = true
+                is PurchaseResult.UserCancelled -> Unit
+                is PurchaseResult.Error -> _errorMessage.value = result.message
+            }
+        }
+    }
+
+    fun clearError() { _errorMessage.value = null }
+    fun clearJustPurchased() { _justPurchased.value = false }
+
+    companion object {
+        fun factory(service: SubscriptionService): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    require(modelClass.isAssignableFrom(SubscriptionViewModel::class.java)) {
+                        "Unknown ViewModel: ${modelClass.name}"
+                    }
+                    return SubscriptionViewModel(service) as T
+                }
+            }
+    }
+}

--- a/ios/OpenClawConsole/OpenClawConsole.xcodeproj/project.pbxproj
+++ b/ios/OpenClawConsole/OpenClawConsole.xcodeproj/project.pbxproj
@@ -11,47 +11,47 @@
 		0802C43B4A799C06A1462B3F /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61E89ABC4C29C3008787294 /* MainTabView.swift */; };
 		084298497D1A6D9535FCE569 /* TaskDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ACD3457578FDCFD63D1F50 /* TaskDetailView.swift */; };
 		0BBA9EA593E3DDAC46089C23 /* TaskListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D928179E99267A56D9E33E52 /* TaskListView.swift */; };
+		0C1AE32553026B2D6E44BF70 /* FleetDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C560C0A66A3D96BECA197352 /* FleetDashboardView.swift */; };
 		1411E663C8A4209F050783A9 /* WebSocketService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E514BCE93EB1F89A2190D0 /* WebSocketService.swift */; };
 		17440A7BE1F4BEFF258E597A /* AgentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADA3CC20D4CDDDEBDD0F5E4 /* AgentDetailView.swift */; };
 		20557B9A641A9353044D4921 /* SeverityBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2AD462AAE57779B0DE9F4E /* SeverityBadge.swift */; };
-		2A712BDDA02317F835CDB2FD /* SubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA102101C6035470CBAF55 /* SubscriptionView.swift */; };
-		315237B0AC0885BA95872322 /* BridgeListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835C9A68460CC97B756BE905 /* BridgeListViewModel.swift */; };
+		276EA882F2F1AFAE8C718DBF /* FleetDashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD4C366AAFD78D5B095C56A /* FleetDashboardViewModel.swift */; };
 		3540FD3BAE80D01B1D1A5426 /* ApprovalRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AF605A05582ADBC8D33C238 /* ApprovalRequest.swift */; };
 		425A3F011AFB84645BC928ED /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4072C9B69E4184E045980D /* APIService.swift */; };
 		4A71CA2536F12EF85385EA67 /* WebSocketMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C385C510F80CD1DC99D9FF1C /* WebSocketMessage.swift */; };
-		54FE0DD8385164F3E82CF3DE /* LoopListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE9D2C7CDAA7190A7BFC68E /* LoopListView.swift */; };
 		583576DE1E6079CE1FDF374D /* OpenClawConsoleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B66EE80BC958A294C6E1C52 /* OpenClawConsoleApp.swift */; };
 		59EDA4E49DC3C2BD35B17F7E /* GatewayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A9BFEF432C2C99D3AB2B64 /* GatewayManager.swift */; };
+		65F61482FA6A22CD31D73941 /* BridgeListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AB1801F557A7EC7E992815 /* BridgeListViewModel.swift */; };
 		684A6ECC0C43B3C005409108 /* GatewayConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D60699A05286D032BA41CA /* GatewayConnection.swift */; };
 		71A77654FEDAB4AD34F8C7AD /* Incident.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CE694F3125DF7DF85A5C1B /* Incident.swift */; };
-		7AF104557BE694319D4C69E7 /* GitViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2541D95F19C1031C40F776B7 /* GitViewModel.swift */; };
-		7AF27E75CEE337C44A408FB3 /* SubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA61FDED4CB7C7C23A65793 /* SubscriptionService.swift */; };
-		7DD46EB04BBC5FACB451F902 /* BridgeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754FAE9E54F091902F14B761 /* BridgeListView.swift */; };
+		71D32708D964456DC80B6206 /* GitViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FE1B71EECCA1C270D53400 /* GitViewModel.swift */; };
+		7B7DEA092D32601645BB358A /* NotificationActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50027C50EE51DB620A077A06 /* NotificationActionHandler.swift */; };
+		7CD68F82EB8F9F585D8B8323 /* SubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D4B8D71B99ECDAA94875B /* SubscriptionService.swift */; };
 		834A119174506349F30E0334 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3999F387613A839206EB5B56 /* ContentView.swift */; };
 		86E92D78B4590725F53CEF47 /* ApprovalBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE8627C1FD4D7384D0F039D /* ApprovalBannerView.swift */; };
 		8C36E210614A9D9FE9E414D7 /* IncidentListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2D4D93012B1AF15CE032EF /* IncidentListViewModel.swift */; };
 		8DD21866F6A167E9B4DA0BBC /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F9FF3A8CA3A0C5D1395632 /* NotificationService.swift */; };
-		90A7F1A2B3C4D5E601234567 /* NotificationActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A7F1A2B3C4D5E601234568 /* NotificationActionHandler.swift */; };
 		953C3B052F95CC93A8040197 /* IncidentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B37EC455A5F78045FA8EA7A /* IncidentDetailView.swift */; };
 		966ECBF0E91A054093E2D67F /* GatewayListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6A371EC180F91BDFA129B9 /* GatewayListView.swift */; };
 		9F737B7808C9CD05B42D4B9B /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842FD483A26BED5A85DC4F7C /* ChatMessage.swift */; };
 		A330FCFB0BA37C7C133E62C6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CED7B8B440732222DBF270DB /* Assets.xcassets */; };
-		A7F1A2B3C4D5E60123456789 /* FleetDashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F1A2B3C4D5E6012345678A /* FleetDashboardViewModel.swift */; };
-		A7F1A2B3C4D5E6012345678B /* FleetDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F1A2B3C4D5E6012345678C /* FleetDashboardView.swift */; };
 		A493D58690FC2CE687DA91D7 /* IncidentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E2C6547FC111A0704755D8 /* IncidentListView.swift */; };
 		AC0FFC34FFACB1A930B10B57 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91ED0911899971B33856481 /* KeychainService.swift */; };
 		AFF4755AB8473B8C3FB0CD59 /* TimeAgoText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1974DC28FE46E8DE552AB153 /* TimeAgoText.swift */; };
 		B0C197E39F3BDB8A72EDAA7F /* TaskDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8869C2C89DE90325B36537 /* TaskDetailViewModel.swift */; };
+		B492807AC771F83C9C5C4B00 /* LoopListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B4348CD784C780DA154616 /* LoopListView.swift */; };
 		B8CB2AE38F3880AB616E876D /* Agent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D025F37633CB3007EC40F5FB /* Agent.swift */; };
 		B9AC8F1FFF6D0DD18AC17F27 /* AgentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9AB1C4AF831D67E0658604 /* AgentListView.swift */; };
+		BDCA8D7C73ACD3F78BF3AFD1 /* LoopListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AC5A64A5860DF199AAE16C /* LoopListViewModel.swift */; };
 		BE269AFA5F5107BE85633437 /* ApprovalDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D0921DCBD4C71D547F7965 /* ApprovalDetailView.swift */; };
-		C5CEBE64263B8C9C3A14ABA4 /* LoopListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFCE7F2EB8D7BD4E2B1FAF4 /* LoopListViewModel.swift */; };
 		C66D3143C15269ECE9DC33E1 /* OCTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9744F34B8396A1E8942101E /* OCTask.swift */; };
 		D28CC7C4AE2D6D5A8F0AC782 /* BiometricService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654A4451670E3B268745438C /* BiometricService.swift */; };
 		D369415E9A00CD7B87587BE7 /* ResourceLinkChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52ACE84DE106112376EC9414 /* ResourceLinkChip.swift */; };
+		D40205F968C7C6DE0109D155 /* BridgeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581A0864C079D5632FA9CC66 /* BridgeListView.swift */; };
 		E26DC6695FC47994160F67D4 /* AddGatewayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB2D0C1CA37A1215F789DAE /* AddGatewayView.swift */; };
 		E4CC40270CBEEB0BA9686BDA /* StatusDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC76505A1ACB7BAEF914F07 /* StatusDot.swift */; };
 		E7E99A351D5E3574C0B2CA1E /* AgentListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BEA5AD6F77FE5CBD437E1E /* AgentListViewModel.swift */; };
+		E89001E0283D9DFA4AC44D9C /* SubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CCD823833E5603691F188F1 /* SubscriptionView.swift */; };
 		ED3EE759CA896EAA866F2020 /* TaskListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693C1589C4E7330AE88DCD42 /* TaskListViewModel.swift */; };
 		F49FB73627F40CD647F65836 /* ApprovalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7465BA19A6F55111388C81A8 /* ApprovalViewModel.swift */; };
 /* End PBXBuildFile section */
@@ -62,10 +62,14 @@
 		0FB2D0C1CA37A1215F789DAE /* AddGatewayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddGatewayView.swift; sourceTree = "<group>"; };
 		16BEA5AD6F77FE5CBD437E1E /* AgentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentListViewModel.swift; sourceTree = "<group>"; };
 		1974DC28FE46E8DE552AB153 /* TimeAgoText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeAgoText.swift; sourceTree = "<group>"; };
-		2541D95F19C1031C40F776B7 /* GitViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GitViewModel.swift; sourceTree = "<group>"; };
-		2EA61FDED4CB7C7C23A65793 /* SubscriptionService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionService.swift; sourceTree = "<group>"; };
+		36AB1801F557A7EC7E992815 /* BridgeListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeListViewModel.swift; sourceTree = "<group>"; };
+		37FE1B71EECCA1C270D53400 /* GitViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitViewModel.swift; sourceTree = "<group>"; };
 		3999F387613A839206EB5B56 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		435D4B8D71B99ECDAA94875B /* SubscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionService.swift; sourceTree = "<group>"; };
+		50027C50EE51DB620A077A06 /* NotificationActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationActionHandler.swift; sourceTree = "<group>"; };
 		52ACE84DE106112376EC9414 /* ResourceLinkChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceLinkChip.swift; sourceTree = "<group>"; };
+		55AC5A64A5860DF199AAE16C /* LoopListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopListViewModel.swift; sourceTree = "<group>"; };
+		581A0864C079D5632FA9CC66 /* BridgeListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeListView.swift; sourceTree = "<group>"; };
 		5B37EC455A5F78045FA8EA7A /* IncidentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncidentDetailView.swift; sourceTree = "<group>"; };
 		5EE8627C1FD4D7384D0F039D /* ApprovalBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalBannerView.swift; sourceTree = "<group>"; };
 		654A4451670E3B268745438C /* BiometricService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricService.swift; sourceTree = "<group>"; };
@@ -73,58 +77,53 @@
 		6941C49BC9627180A9025CEB /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		6F2D4D93012B1AF15CE032EF /* IncidentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncidentListViewModel.swift; sourceTree = "<group>"; };
 		7465BA19A6F55111388C81A8 /* ApprovalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalViewModel.swift; sourceTree = "<group>"; };
-		754FAE9E54F091902F14B761 /* BridgeListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BridgeListView.swift; sourceTree = "<group>"; };
 		7AF605A05582ADBC8D33C238 /* ApprovalRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalRequest.swift; sourceTree = "<group>"; };
 		7B66EE80BC958A294C6E1C52 /* OpenClawConsoleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenClawConsoleApp.swift; sourceTree = "<group>"; };
-		7EE9D2C7CDAA7190A7BFC68E /* LoopListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoopListView.swift; sourceTree = "<group>"; };
-		835C9A68460CC97B756BE905 /* BridgeListViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BridgeListViewModel.swift; sourceTree = "<group>"; };
 		842FD483A26BED5A85DC4F7C /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		84E514BCE93EB1F89A2190D0 /* WebSocketService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketService.swift; sourceTree = "<group>"; };
 		8A2AD462AAE57779B0DE9F4E /* SeverityBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeverityBadge.swift; sourceTree = "<group>"; };
+		8CCD823833E5603691F188F1 /* SubscriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionView.swift; sourceTree = "<group>"; };
 		93CE694F3125DF7DF85A5C1B /* Incident.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Incident.swift; sourceTree = "<group>"; };
-		9BFCE7F2EB8D7BD4E2B1FAF4 /* LoopListViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoopListViewModel.swift; sourceTree = "<group>"; };
 		ADC76505A1ACB7BAEF914F07 /* StatusDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusDot.swift; sourceTree = "<group>"; };
 		B0ACD3457578FDCFD63D1F50 /* TaskDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailView.swift; sourceTree = "<group>"; };
+		B4B4348CD784C780DA154616 /* LoopListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopListView.swift; sourceTree = "<group>"; };
 		B6D0921DCBD4C71D547F7965 /* ApprovalDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalDetailView.swift; sourceTree = "<group>"; };
 		BA6A371EC180F91BDFA129B9 /* GatewayListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayListView.swift; sourceTree = "<group>"; };
+		BBD4C366AAFD78D5B095C56A /* FleetDashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDashboardViewModel.swift; sourceTree = "<group>"; };
 		C0A9BFEF432C2C99D3AB2B64 /* GatewayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayManager.swift; sourceTree = "<group>"; };
 		C385C510F80CD1DC99D9FF1C /* WebSocketMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketMessage.swift; sourceTree = "<group>"; };
+		C560C0A66A3D96BECA197352 /* FleetDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDashboardView.swift; sourceTree = "<group>"; };
 		C61E89ABC4C29C3008787294 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		C91ED0911899971B33856481 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		CADA3CC20D4CDDDEBDD0F5E4 /* AgentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetailView.swift; sourceTree = "<group>"; };
 		CED7B8B440732222DBF270DB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D025F37633CB3007EC40F5FB /* Agent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent.swift; sourceTree = "<group>"; };
 		D2F9FF3A8CA3A0C5D1395632 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
-		90A7F1A2B3C4D5E601234568 /* NotificationActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationActionHandler.swift; sourceTree = "<group>"; };
 		D928179E99267A56D9E33E52 /* TaskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListView.swift; sourceTree = "<group>"; };
 		D9744F34B8396A1E8942101E /* OCTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCTask.swift; sourceTree = "<group>"; };
 		DE4072C9B69E4184E045980D /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		DF1A595D54FA8D215174F303 /* OpenClawConsole.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = OpenClawConsole.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF8869C2C89DE90325B36537 /* TaskDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailViewModel.swift; sourceTree = "<group>"; };
 		E3E2C6547FC111A0704755D8 /* IncidentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncidentListView.swift; sourceTree = "<group>"; };
-		E6FA102101C6035470CBAF55 /* SubscriptionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionView.swift; sourceTree = "<group>"; };
-		A7F1A2B3C4D5E6012345678A /* FleetDashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDashboardViewModel.swift; sourceTree = "<group>"; };
-		A7F1A2B3C4D5E6012345678C /* FleetDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDashboardView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
 		0316CDEF9ADF932B23A91237 /* Views */ = {
 			isa = PBXGroup;
-				children = (
-					3999F387613A839206EB5B56 /* ContentView.swift */,
-					C61E89ABC4C29C3008787294 /* MainTabView.swift */,
-					0B7400156998A215FDD3F85F /* Agents */,
-					2261603496B3CF0F0F6A0D1F /* Approvals */,
-					06143CA74AA11898DD6EC38A /* Chat */,
-					A6267BD60FFBC7F3FC6C08AE /* Components */,
-					A7F1A2B3C4D5E6012345678D /* Dashboard */,
-					B30878B13876FCA0C31050C1 /* Incidents */,
-					04C5E0146D1D1236FCF0AAB8 /* Settings */,
-					E6769E232CBDC15EDA6FD49C /* Tasks */,
-					8DA992D7EDDFC96A9CEF51A9 /* Bridges */,
-				B42E9C2B92515022D081DA80 /* Loops */,
-				6B5A8C82D83EB6F57C95ACB2 /* Git */,
-				E6FA102101C6035470CBAF55 /* SubscriptionView.swift */,
+			children = (
+				3999F387613A839206EB5B56 /* ContentView.swift */,
+				C61E89ABC4C29C3008787294 /* MainTabView.swift */,
+				8CCD823833E5603691F188F1 /* SubscriptionView.swift */,
+				0B7400156998A215FDD3F85F /* Agents */,
+				2261603496B3CF0F0F6A0D1F /* Approvals */,
+				7EF7C13838EA9504CC79CAA1 /* Bridges */,
+				06143CA74AA11898DD6EC38A /* Chat */,
+				A6267BD60FFBC7F3FC6C08AE /* Components */,
+				26A5B8F53B420C2DA09F38DA /* Dashboard */,
+				B30878B13876FCA0C31050C1 /* Incidents */,
+				4730B9DABDC9EACA167D04D4 /* Loops */,
+				04C5E0146D1D1236FCF0AAB8 /* Settings */,
+				E6769E232CBDC15EDA6FD49C /* Tasks */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -172,15 +171,15 @@
 			isa = PBXGroup;
 			children = (
 				16BEA5AD6F77FE5CBD437E1E /* AgentListViewModel.swift */,
-					7465BA19A6F55111388C81A8 /* ApprovalViewModel.swift */,
-					C0A9BFEF432C2C99D3AB2B64 /* GatewayManager.swift */,
-					6F2D4D93012B1AF15CE032EF /* IncidentListViewModel.swift */,
-					DF8869C2C89DE90325B36537 /* TaskDetailViewModel.swift */,
-					693C1589C4E7330AE88DCD42 /* TaskListViewModel.swift */,
-					835C9A68460CC97B756BE905 /* BridgeListViewModel.swift */,
-					A7F1A2B3C4D5E6012345678A /* FleetDashboardViewModel.swift */,
-					9BFCE7F2EB8D7BD4E2B1FAF4 /* LoopListViewModel.swift */,
-					2541D95F19C1031C40F776B7 /* GitViewModel.swift */,
+				7465BA19A6F55111388C81A8 /* ApprovalViewModel.swift */,
+				36AB1801F557A7EC7E992815 /* BridgeListViewModel.swift */,
+				BBD4C366AAFD78D5B095C56A /* FleetDashboardViewModel.swift */,
+				C0A9BFEF432C2C99D3AB2B64 /* GatewayManager.swift */,
+				37FE1B71EECCA1C270D53400 /* GitViewModel.swift */,
+				6F2D4D93012B1AF15CE032EF /* IncidentListViewModel.swift */,
+				55AC5A64A5860DF199AAE16C /* LoopListViewModel.swift */,
+				DF8869C2C89DE90325B36537 /* TaskDetailViewModel.swift */,
+				693C1589C4E7330AE88DCD42 /* TaskListViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -192,6 +191,14 @@
 				B6D0921DCBD4C71D547F7965 /* ApprovalDetailView.swift */,
 			);
 			path = Approvals;
+			sourceTree = "<group>";
+		};
+		26A5B8F53B420C2DA09F38DA /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				C560C0A66A3D96BECA197352 /* FleetDashboardView.swift */,
+			);
+			path = Dashboard;
 			sourceTree = "<group>";
 		};
 		386E84F76E8D76809ABB8DE2 = {
@@ -210,32 +217,25 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		6B5A8C82D83EB6F57C95ACB2 /* Git */ = {
+		4730B9DABDC9EACA167D04D4 /* Loops */ = {
 			isa = PBXGroup;
 			children = (
+				B4B4348CD784C780DA154616 /* LoopListView.swift */,
 			);
-			path = Git;
+			path = Loops;
 			sourceTree = "<group>";
 		};
-			8DA992D7EDDFC96A9CEF51A9 /* Bridges */ = {
-				isa = PBXGroup;
-				children = (
-					754FAE9E54F091902F14B761 /* BridgeListView.swift */,
-				);
-				path = Bridges;
-				sourceTree = "<group>";
-			};
-			A7F1A2B3C4D5E6012345678D /* Dashboard */ = {
-				isa = PBXGroup;
-				children = (
-					A7F1A2B3C4D5E6012345678C /* FleetDashboardView.swift */,
-				);
-				path = Dashboard;
-				sourceTree = "<group>";
-			};
-			A6267BD60FFBC7F3FC6C08AE /* Components */ = {
-				isa = PBXGroup;
-				children = (
+		7EF7C13838EA9504CC79CAA1 /* Bridges */ = {
+			isa = PBXGroup;
+			children = (
+				581A0864C079D5632FA9CC66 /* BridgeListView.swift */,
+			);
+			path = Bridges;
+			sourceTree = "<group>";
+		};
+		A6267BD60FFBC7F3FC6C08AE /* Components */ = {
+			isa = PBXGroup;
+			children = (
 				52ACE84DE106112376EC9414 /* ResourceLinkChip.swift */,
 				8A2AD462AAE57779B0DE9F4E /* SeverityBadge.swift */,
 				ADC76505A1ACB7BAEF914F07 /* StatusDot.swift */,
@@ -253,14 +253,6 @@
 			path = Incidents;
 			sourceTree = "<group>";
 		};
-		B42E9C2B92515022D081DA80 /* Loops */ = {
-			isa = PBXGroup;
-			children = (
-				7EE9D2C7CDAA7190A7BFC68E /* LoopListView.swift */,
-			);
-			path = Loops;
-			sourceTree = "<group>";
-		};
 		E6769E232CBDC15EDA6FD49C /* Tasks */ = {
 			isa = PBXGroup;
 			children = (
@@ -271,15 +263,15 @@
 			sourceTree = "<group>";
 		};
 		F845E0B17B0AF7DD02686BF0 /* Services */ = {
-				isa = PBXGroup;
-				children = (
-					DE4072C9B69E4184E045980D /* APIService.swift */,
-					654A4451670E3B268745438C /* BiometricService.swift */,
-					C91ED0911899971B33856481 /* KeychainService.swift */,
-					90A7F1A2B3C4D5E601234568 /* NotificationActionHandler.swift */,
-					D2F9FF3A8CA3A0C5D1395632 /* NotificationService.swift */,
-					84E514BCE93EB1F89A2190D0 /* WebSocketService.swift */,
-					2EA61FDED4CB7C7C23A65793 /* SubscriptionService.swift */,
+			isa = PBXGroup;
+			children = (
+				DE4072C9B69E4184E045980D /* APIService.swift */,
+				654A4451670E3B268745438C /* BiometricService.swift */,
+				C91ED0911899971B33856481 /* KeychainService.swift */,
+				50027C50EE51DB620A077A06 /* NotificationActionHandler.swift */,
+				D2F9FF3A8CA3A0C5D1395632 /* NotificationService.swift */,
+				435D4B8D71B99ECDAA94875B /* SubscriptionService.swift */,
+				84E514BCE93EB1F89A2190D0 /* WebSocketService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -300,23 +292,12 @@
 		};
 /* End PBXGroup section */
 
-/* Begin PBXFrameworksBuildPhase section */
-		F1A2B3C4D5E6F78901234567 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
 /* Begin PBXNativeTarget section */
 		D73E99810B13C310036F9B93 /* OpenClawConsole */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3F26A693C9973452D55D440B /* Build configuration list for PBXNativeTarget "OpenClawConsole" */;
 			buildPhases = (
 				AC55413DEC7B34043F71182C /* Sources */,
-				F1A2B3C4D5E6F78901234567 /* Frameworks */,
 				D3B4FE988C1C4DC28FAAF903 /* Resources */,
 			);
 			buildRules = (
@@ -325,7 +306,6 @@
 			);
 			name = OpenClawConsole;
 			packageProductDependencies = (
-				68580805BBBBCB9FAE99A2EC /* RevenueCat */,
 			);
 			productName = OpenClawConsole;
 			productReference = DF1A595D54FA8D215174F303 /* OpenClawConsole.app */;
@@ -346,7 +326,6 @@
 				};
 			};
 			buildConfigurationList = 357B68605B3C7E351822A9CB /* Build configuration list for PBXProject "OpenClawConsole" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -355,9 +334,6 @@
 			);
 			mainGroup = 386E84F76E8D76809ABB8DE2;
 			minimizedProjectReferenceProxies = 1;
-			packageReferences = (
-				2E26F0F02A51817D55CFC18A /* XCRemoteSwiftPackageReference "purchases-ios" */,
-			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 400013C51CE1D6B56A9B4C2E /* Products */;
 			projectDirPath = "";
@@ -395,25 +371,34 @@
 				3540FD3BAE80D01B1D1A5426 /* ApprovalRequest.swift in Sources */,
 				F49FB73627F40CD647F65836 /* ApprovalViewModel.swift in Sources */,
 				D28CC7C4AE2D6D5A8F0AC782 /* BiometricService.swift in Sources */,
+				D40205F968C7C6DE0109D155 /* BridgeListView.swift in Sources */,
+				65F61482FA6A22CD31D73941 /* BridgeListViewModel.swift in Sources */,
 				9F737B7808C9CD05B42D4B9B /* ChatMessage.swift in Sources */,
 				02411DA368F00CCFB1B17CE1 /* ChatView.swift in Sources */,
 				834A119174506349F30E0334 /* ContentView.swift in Sources */,
+				0C1AE32553026B2D6E44BF70 /* FleetDashboardView.swift in Sources */,
+				276EA882F2F1AFAE8C718DBF /* FleetDashboardViewModel.swift in Sources */,
 				684A6ECC0C43B3C005409108 /* GatewayConnection.swift in Sources */,
 				966ECBF0E91A054093E2D67F /* GatewayListView.swift in Sources */,
 				59EDA4E49DC3C2BD35B17F7E /* GatewayManager.swift in Sources */,
+				71D32708D964456DC80B6206 /* GitViewModel.swift in Sources */,
 				71A77654FEDAB4AD34F8C7AD /* Incident.swift in Sources */,
 				953C3B052F95CC93A8040197 /* IncidentDetailView.swift in Sources */,
 				A493D58690FC2CE687DA91D7 /* IncidentListView.swift in Sources */,
 				8C36E210614A9D9FE9E414D7 /* IncidentListViewModel.swift in Sources */,
 				AC0FFC34FFACB1A930B10B57 /* KeychainService.swift in Sources */,
+				B492807AC771F83C9C5C4B00 /* LoopListView.swift in Sources */,
+				BDCA8D7C73ACD3F78BF3AFD1 /* LoopListViewModel.swift in Sources */,
 				0802C43B4A799C06A1462B3F /* MainTabView.swift in Sources */,
-				90A7F1A2B3C4D5E601234567 /* NotificationActionHandler.swift in Sources */,
+				7B7DEA092D32601645BB358A /* NotificationActionHandler.swift in Sources */,
 				8DD21866F6A167E9B4DA0BBC /* NotificationService.swift in Sources */,
 				C66D3143C15269ECE9DC33E1 /* OCTask.swift in Sources */,
 				583576DE1E6079CE1FDF374D /* OpenClawConsoleApp.swift in Sources */,
 				D369415E9A00CD7B87587BE7 /* ResourceLinkChip.swift in Sources */,
 				20557B9A641A9353044D4921 /* SeverityBadge.swift in Sources */,
 				E4CC40270CBEEB0BA9686BDA /* StatusDot.swift in Sources */,
+				7CD68F82EB8F9F585D8B8323 /* SubscriptionService.swift in Sources */,
+				E89001E0283D9DFA4AC44D9C /* SubscriptionView.swift in Sources */,
 				084298497D1A6D9535FCE569 /* TaskDetailView.swift in Sources */,
 				B0C197E39F3BDB8A72EDAA7F /* TaskDetailViewModel.swift in Sources */,
 				0BBA9EA593E3DDAC46089C23 /* TaskListView.swift in Sources */,
@@ -421,15 +406,6 @@
 				AFF4755AB8473B8C3FB0CD59 /* TimeAgoText.swift in Sources */,
 				4A71CA2536F12EF85385EA67 /* WebSocketMessage.swift in Sources */,
 				1411E663C8A4209F050783A9 /* WebSocketService.swift in Sources */,
-				315237B0AC0885BA95872322 /* BridgeListViewModel.swift in Sources */,
-				A7F1A2B3C4D5E6012345678B /* FleetDashboardView.swift in Sources */,
-				A7F1A2B3C4D5E60123456789 /* FleetDashboardViewModel.swift in Sources */,
-				C5CEBE64263B8C9C3A14ABA4 /* LoopListViewModel.swift in Sources */,
-				7AF104557BE694319D4C69E7 /* GitViewModel.swift in Sources */,
-				7DD46EB04BBC5FACB451F902 /* BridgeListView.swift in Sources */,
-				2A712BDDA02317F835CDB2FD /* SubscriptionView.swift in Sources */,
-				54FE0DD8385164F3E82CF3DE /* LoopListView.swift in Sources */,
-				7AF27E75CEE337C44A408FB3 /* SubscriptionService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -623,25 +599,6 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		2E26F0F02A51817D55CFC18A /* XCRemoteSwiftPackageReference "purchases-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/RevenueCat/purchases-ios.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.0.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		68580805BBBBCB9FAE99A2EC /* RevenueCat */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2E26F0F02A51817D55CFC18A /* XCRemoteSwiftPackageReference "purchases-ios" */;
-			productName = RevenueCat;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = CCC4285A4910BCC03DF52580 /* Project object */;
 }

--- a/ios/OpenClawConsole/OpenClawConsole.xcodeproj/project.pbxproj
+++ b/ios/OpenClawConsole/OpenClawConsole.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0BBA9EA593E3DDAC46089C23 /* TaskListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D928179E99267A56D9E33E52 /* TaskListView.swift */; };
 		0C1AE32553026B2D6E44BF70 /* FleetDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C560C0A66A3D96BECA197352 /* FleetDashboardView.swift */; };
 		1411E663C8A4209F050783A9 /* WebSocketService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E514BCE93EB1F89A2190D0 /* WebSocketService.swift */; };
+		16A1BD2710BF953FACC6331F /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 38D99F4B062A6E575A5E59DE /* RevenueCat */; };
 		17440A7BE1F4BEFF258E597A /* AgentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADA3CC20D4CDDDEBDD0F5E4 /* AgentDetailView.swift */; };
 		20557B9A641A9353044D4921 /* SeverityBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2AD462AAE57779B0DE9F4E /* SeverityBadge.swift */; };
 		276EA882F2F1AFAE8C718DBF /* FleetDashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD4C366AAFD78D5B095C56A /* FleetDashboardViewModel.swift */; };
@@ -106,6 +107,17 @@
 		DF8869C2C89DE90325B36537 /* TaskDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailViewModel.swift; sourceTree = "<group>"; };
 		E3E2C6547FC111A0704755D8 /* IncidentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncidentListView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8129656D69330E1F3532DA9F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				16A1BD2710BF953FACC6331F /* RevenueCat in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		0316CDEF9ADF932B23A91237 /* Views */ = {
@@ -299,6 +311,7 @@
 			buildPhases = (
 				AC55413DEC7B34043F71182C /* Sources */,
 				D3B4FE988C1C4DC28FAAF903 /* Resources */,
+				8129656D69330E1F3532DA9F /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -306,6 +319,7 @@
 			);
 			name = OpenClawConsole;
 			packageProductDependencies = (
+				38D99F4B062A6E575A5E59DE /* RevenueCat */,
 			);
 			productName = OpenClawConsole;
 			productReference = DF1A595D54FA8D215174F303 /* OpenClawConsole.app */;
@@ -334,6 +348,9 @@
 			);
 			mainGroup = 386E84F76E8D76809ABB8DE2;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				5C34E63B4FD6DD8C0C6F4579 /* XCRemoteSwiftPackageReference "purchases-ios" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 400013C51CE1D6B56A9B4C2E /* Products */;
 			projectDirPath = "";
@@ -599,6 +616,25 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		5C34E63B4FD6DD8C0C6F4579 /* XCRemoteSwiftPackageReference "purchases-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.67.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		38D99F4B062A6E575A5E59DE /* RevenueCat */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5C34E63B4FD6DD8C0C6F4579 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+			productName = RevenueCat;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = CCC4285A4910BCC03DF52580 /* Project object */;
 }

--- a/ios/OpenClawConsole/project.yml
+++ b/ios/OpenClawConsole/project.yml
@@ -14,7 +14,10 @@ settings:
     CODE_SIGN_STYLE: Automatic
     GENERATE_INFOPLIST_FILE: NO
     TARGETED_DEVICE_FAMILY: "1,2"
-packages: {}
+packages:
+  RevenueCat:
+    url: https://github.com/RevenueCat/purchases-ios
+    from: 5.67.2
 targets:
   OpenClawConsole:
     type: application
@@ -23,6 +26,9 @@ targets:
       - path: OpenClawConsole
         excludes:
           - Info.plist
+    dependencies:
+      - package: RevenueCat
+        product: RevenueCat
     settings:
       base:
         PRODUCT_MODULE_NAME: OpenClawConsole


### PR DESCRIPTION
## Summary

This PR bundles two unblocking changes the Android+iOS pipeline needed:

### 1. Distribution auth fixes (original scope)
- **iOS TestFlight** was failing at the match step with `Authentication failed for '***/'`. Root cause: the `MATCH_GIT_BASIC_AUTHORIZATION` secret was created with a GitHub password-auth token, which GitHub no longer supports. Fix: derive the header inline from the already-valid `ADMIN_TOKEN`.
- **Android Firebase** was failing with `❌ Firebase project ***-console-mobile not accessible or does not exist`. Root cause: the workflow hardcoded `openclaw-console-mobile` in its project-existence check, ignoring the actual `FIREBASE_PROJECT_ID` secret. Fix: resolve from the secret first, then fall back to `project_id` in `google-services.json`.
- Also removed a premature `unset FIREBASE_TOKEN` that was killing the retry fallback before it ran.

### 2. Android monetization (mirrors iOS)
Without this, the North Star (Daily Active Approvers) has no revenue backstop on Android.

- `SubscriptionService` + `SubscriptionModels` in `service/subscription/` — RevenueCat 9.29.1 wrapper with `pro` entitlement, `com.openclaw.console.pro.{monthly,yearly}` product IDs. IDs match iOS so a user's Pro entitlement is portable across platforms.
- `PaywallScreen` + `SubscriptionViewModel` under `ui/screens/subscription/` — full paywall UI (header, status, feature comparison, offerings, restore, error banner, config-missing notice).
- `OpenClawApplication.onCreate` configures RevenueCat from `BuildConfig.REVENUECAT_PUBLIC_KEY` (CI-injected).
- Settings screen shows an "Upgrade to Pro" CTA that navigates to `Screen.Paywall`.
- Feature gate catalog matches iOS (`devops_integrations`, `advanced_analytics`, `custom_webhooks`, `priority_support`, `unlimited_agents` are Pro-only).

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes locally
- [x] CI Android Build Check passes
- [x] CI iOS Build Check passes
- [ ] Merge triggers `Internal Distribution` via `workflow_run` on green CI
- [ ] iOS `Setup signing certificates and profiles (match)` completes
- [ ] Android `Distribute to internal Firebase tester(s)` completes
- [ ] TestFlight + Firebase App Distribution emails arrive at iganapolsky@gmail.com
- [ ] Paywall screen renders when `REVENUECAT_PUBLIC_KEY` is empty (shows "not configured" notice)
- [ ] Paywall screen shows offerings when `REVENUECAT_PUBLIC_KEY` is set + products are live on Play Console

## Out of scope (tracked separately)
- RevenueCat dashboard setup (entitlement, products, offerings)
- Google Play Console in-app product creation
- Observability (PostHog / Sentry / Crashlytics / Firebase Analytics) — not wired on either platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)