### PR TITLE
fix: enforce real CI coverage on develop PRs

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -3,18 +3,18 @@ name: iOS CI
 on:
   pull_request:
     paths:
-      - 'openclaw-skills/ios/**'
+      - 'ios/**'
   push:
     branches: [main, develop]
     paths:
-      - 'openclaw-skills/ios/**'
+      - 'ios/**'
 
 jobs:
   build-and-test:
     runs-on: macos-14
     defaults:
       run:
-        working-directory: openclaw-skills/ios/OpenClawConsole
+        working-directory: ios/OpenClawConsole
 
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     runs-on: macos-14
     defaults:
       run:
-        working-directory: openclaw-skills/ios/OpenClawConsole
+        working-directory: ios/OpenClawConsole
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-state-machine.yml
+++ b/.github/workflows/pr-state-machine.yml
@@ -85,18 +85,25 @@ jobs:
                 .filter((v) => v.length > 0);
             }
 
+            function mergeContexts(...lists) {
+              return [...new Set(lists.flat().filter((value) => value && value.length > 0))];
+            }
+
             function getRequiredContextsFallback(baseBranch) {
               const normalized = baseBranch.toUpperCase().replace(/[^A-Z0-9]/g, "_");
               const branchEnvName = `REQUIRED_CHECKS_${normalized}`;
+              const workflowDefault = DEFAULT_REQUIRED_CHECKS[baseBranch] || [];
               const branchFallback = parseRequiredChecks(process.env[branchEnvName] || "");
               if (branchFallback.length > 0) {
+                const contexts = mergeContexts(workflowDefault, branchFallback);
                 return {
-                  contexts: branchFallback,
-                  source: `vars.PR_REQUIRED_CHECKS_${normalized}`
+                  contexts,
+                  source: workflowDefault.length > 0
+                    ? `workflow_default:${baseBranch}+vars.PR_REQUIRED_CHECKS_${normalized}`
+                    : `vars.PR_REQUIRED_CHECKS_${normalized}`
                 };
               }
 
-              const workflowDefault = DEFAULT_REQUIRED_CHECKS[baseBranch] || [];
               if (workflowDefault.length > 0) {
                 return {
                   contexts: workflowDefault,
@@ -106,9 +113,12 @@ jobs:
 
               const fallbackFromVar = parseRequiredChecks(process.env.REQUIRED_CHECKS_FROM_VAR || "");
               if (fallbackFromVar.length > 0) {
+                const contexts = mergeContexts(workflowDefault, fallbackFromVar);
                 return {
-                  contexts: fallbackFromVar,
-                  source: "vars.PR_REQUIRED_CHECKS"
+                  contexts,
+                  source: workflowDefault.length > 0
+                    ? `workflow_default:${baseBranch}+vars.PR_REQUIRED_CHECKS`
+                    : "vars.PR_REQUIRED_CHECKS"
                 };
               }
 

--- a/.github/workflows/pr-state-machine.yml
+++ b/.github/workflows/pr-state-machine.yml
@@ -49,7 +49,15 @@ jobs:
             const FAILING_STATES = new Set(["error", "failure"]);
             const PENDING_STATES = new Set(["pending"]);
             const DEFAULT_REQUIRED_CHECKS = {
-              develop: ["Skills Tests", "Architecture Lint (Kotlin)", "Architecture Lint (Swift)"],
+              develop: [
+                "Skills Tests",
+                "Architecture Lint (Kotlin)",
+                "Architecture Lint (Swift)",
+                "Android Build Check",
+                "iOS Build Check",
+                "Secrets Scan",
+                "Dependency Audit"
+              ],
               main: [
                 "Skills Tests",
                 "Architecture Lint (Kotlin)",
@@ -138,6 +146,7 @@ jobs:
             }
 
             async function getRequiredContexts(baseBranch) {
+              const fallback = getRequiredContextsFallback(baseBranch);
               try {
                 const protection = await github.rest.repos.getBranchProtection({
                   owner,
@@ -152,15 +161,23 @@ jobs:
                   }
                 }
 
+                if (baseBranch === "develop") {
+                  for (const context of fallback.contexts) {
+                    contexts.add(context);
+                  }
+                }
+
                 return {
                   contexts: [...contexts],
-                  source: "branch_protection"
+                  source: baseBranch === "develop" && fallback.contexts.length > 0
+                    ? `branch_protection+${fallback.source}`
+                    : "branch_protection"
                 };
               } catch (error) {
                 core.warning(`Branch protection lookup failed for ${baseBranch}: ${error.message}`);
               }
 
-              return getRequiredContextsFallback(baseBranch);
+              return fallback;
             }
 
             async function getCheckRunMap(headSha) {


### PR DESCRIPTION
## Summary
- fix the iOS CI workflow to watch and build the real `ios/**` tree
- make `pr/state-machine` enforce the repo's minimum CI set on `develop` PRs instead of trusting the current lightweight branch-protection contexts alone
- keep the change narrow to CI governance so open dependency PR readiness becomes trustworthy

## Root Cause
`pr/state-machine` was deferring to branch protection when available, and branch protection on `develop` currently only requires lightweight security/status contexts. Separately, `ios.yml` was pointed at `openclaw-skills/ios/**`, so iOS dependency PRs were not covered by the dedicated iOS workflow.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ios.yml'); YAML.load_file('.github/workflows/pr-state-machine.yml'); puts 'yaml-ok'"`
- manual diff review of `.github/workflows/ios.yml` and `.github/workflows/pr-state-machine.yml`
- `gh pr checks 219`, `gh pr checks 229`, `gh pr checks 232` showed only `3/3 required checks`, confirming the weak gating before this fix
