### PR TITLE
fix: lift Android toolchain to API 36 floor

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: android
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -51,7 +51,7 @@ jobs:
         working-directory: android
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -66,7 +66,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run Android Lint
-        run: ./gradlew lintDebug || echo "::warning::Android Lint crashed (known AGP 8.7.3 bug) — see uploaded report"
+        run: ./gradlew lintDebug || echo "::warning::Android Lint crashed due to a known AGP/Compose tooling issue — see uploaded report"
 
       - name: Upload lint results
         if: always()

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.openclaw.console"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.openclaw.console"
@@ -77,7 +77,7 @@ android {
         disable += "RememberInComposition"
         disable += "FrequentlyChangingValue"
         disable += "AutoboxingStateCreation"
-        // AGP 8.7.3 lint crashes with IncompatibleClassChangeError on multiple Compose/Lifecycle detectors.
+        // AGP lint remains noisy around several Compose/Lifecycle detectors in CI.
         // This is a known tooling bug, not a code issue. The build itself compiles fine.
         abortOnError = false
     }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.application") version "8.7.3" apply false
+    id("com.android.application") version "8.9.2" apply false
     id("org.jetbrains.kotlin.android") version "2.1.21" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.1.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.21" apply false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- upgrade AGP from 8.7.3 to 8.9.2
- upgrade the Gradle wrapper from 8.10.2 to 8.11.1
- raise Android `compileSdk` to 36 while keeping `targetSdk` at 35
- update Android CI to `actions/checkout@v5` and correct the lint warning text

## Why
`develop` currently fails `./gradlew assembleDebug` after the `androidx.activity:activity-compose:1.13.0` bump. The failure is `:app:checkDebugAarMetadata`, with dependencies requiring API 36 and AGP 8.9.1+.

Official Android docs for API 36.0 list AGP 8.9.1 as the minimum supported version, and AGP 8.9 requires Gradle 8.11.1.

## Verification
- baseline on `origin/develop` before this patch: `./gradlew assembleDebug` failed on `:app:checkDebugAarMetadata`
- after this patch:
  - `./gradlew --version` -> Gradle 8.11.1
  - `./gradlew assembleDebug` -> BUILD SUCCESSFUL
  - `./gradlew testDebugUnitTest lintDebug` -> BUILD SUCCESSFUL
