### PR TITLE
fix: support okhttp 5.3.2 in Android app

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -85,6 +85,7 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            excludes += "/META-INF/versions/9/OSGI-INF/MANIFEST.MF"
         }
     }
 }
@@ -118,8 +119,8 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
 
     // OkHttp (WebSocket + HTTP)
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
-    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+    implementation("com.squareup.okhttp3:okhttp:5.3.2")
+    implementation("com.squareup.okhttp3:logging-interceptor:5.3.2")
 
     // Kotlinx Serialization (1.8.1 is the latest version compatible with Kotlin 2.1.x)
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
@@ -144,7 +145,7 @@ dependencies {
     // Test
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")


### PR DESCRIPTION
## Summary
- bump Android OkHttp, logging-interceptor, and mockwebserver to 5.3.2 together
- exclude the duplicate OSGI manifest that breaks mergeDebugJavaResource
- verify the Android app still builds, tests, and lints cleanly

## Verification
- ./gradlew assembleDebug testDebugUnitTest lintDebug

Supersedes #224.