### PR TITLE
chore: bump @slack/oauth to 3.0.5

### DIFF
--- a/openclaw-skills/package-lock.json
+++ b/openclaw-skills/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@revenuecat/purchases-js": "^1.35.0",
-        "@slack/oauth": "^3.0.4",
+        "@slack/oauth": "^3.0.5",
         "@slack/web-api": "^7.15.1",
         "express": "^5.2.1",
         "firebase-admin": "^13.7.0",
@@ -2337,13 +2337,13 @@
       }
     },
     "node_modules/@slack/oauth": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-3.0.4.tgz",
-      "integrity": "sha512-+8H0g7mbrHndEUbYCP7uYyBCbwqmm3E6Mo3nfsDvZZW74zKk1ochfH/fWSvGInYNCVvaBUbg3RZBbTp0j8yJCg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-3.0.5.tgz",
+      "integrity": "sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A==",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4",
-        "@slack/web-api": "^7.10.0",
+        "@slack/logger": "^4.0.1",
+        "@slack/web-api": "^7.15.0",
         "@types/jsonwebtoken": "^9",
         "@types/node": ">=18",
         "jsonwebtoken": "^9"

--- a/openclaw-skills/package.json
+++ b/openclaw-skills/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@revenuecat/purchases-js": "^1.35.0",
-    "@slack/oauth": "^3.0.4",
+    "@slack/oauth": "^3.0.5",
     "@slack/web-api": "^7.15.1",
     "express": "^5.2.1",
     "firebase-admin": "^13.7.0",


### PR DESCRIPTION
## Summary
- bump  from  to  on top of the already-merged Slack web API and TypeScript updates
- refresh the lockfile from current  so the branch is mergeable again

## Verification
- 
> @openclaw-console/skills@1.0.0 lint
> eslint src tests --ext .ts
- 
> @openclaw-console/skills@1.0.0 build
> tsc
- 
> @openclaw-console/skills@1.0.0 test
> node --experimental-vm-modules node_modules/.bin/jest --passWithNoTests --runInBand
- result:  suites,  tests passed

Supersedes #227.