### PR TITLE
fix: simplify Android screens toward iOS parity

### DIFF
--- a/android/app/src/main/java/com/openclaw/console/ui/screens/bridges/BridgeListScreen.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/bridges/BridgeListScreen.kt
@@ -5,7 +5,10 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
@@ -29,7 +32,6 @@ fun BridgeListScreen(
     viewModel: BridgeViewModel = viewModel()
 ) {
     val bridgeRepo by appViewModel.bridgeRepository.collectAsStateWithLifecycle()
-    val connectionState by appViewModel.connectionState.collectAsStateWithLifecycle()
 
     LaunchedEffect(bridgeRepo) {
         viewModel.setRepository(bridgeRepo)
@@ -39,6 +41,7 @@ fun BridgeListScreen(
     var isRefreshing by remember { mutableStateOf(false) }
 
     Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
                 title = {
@@ -67,9 +70,6 @@ fun BridgeListScreen(
                 .padding(paddingValues)
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
-                // Connection status banner
-                ConnectionStatusBanner(state = connectionState)
-
                 // Error state
                 uiState.error?.let { error ->
                     Card(
@@ -115,12 +115,12 @@ fun BridgeListScreen(
                         }
                     }
                     else -> {
-                        LazyColumn(
-                            modifier = Modifier.fillMaxSize(),
-                            contentPadding = PaddingValues(vertical = 4.dp)
-                        ) {
-                            items(
-                                items = uiState.sessions,
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(vertical = 8.dp)
+                    ) {
+                        items(
+                            items = uiState.sessions,
                                 key = { it.id }
                             ) { session ->
                                 BridgeSessionItem(session = session)
@@ -136,7 +136,9 @@ fun BridgeListScreen(
 @Composable
 private fun BridgeSessionItem(session: BridgeSession) {
     ListItem(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp),
         headlineContent = {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -184,7 +186,8 @@ private fun BridgeSessionItem(session: BridgeSession) {
                 }
                 TimeAgoText(session.createdAt, style = MaterialTheme.typography.labelSmall)
             }
-        }
+        },
+        colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.surface)
     )
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 }

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/incidents/IncidentListScreen.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/incidents/IncidentListScreen.kt
@@ -5,7 +5,11 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
@@ -27,7 +31,6 @@ fun IncidentListScreen(
     viewModel: IncidentViewModel = viewModel()
 ) {
     val incidentRepo by appViewModel.incidentRepository.collectAsStateWithLifecycle()
-    val connectionState by appViewModel.connectionState.collectAsStateWithLifecycle()
 
     LaunchedEffect(incidentRepo) {
         viewModel.setRepository(incidentRepo)
@@ -35,8 +38,10 @@ fun IncidentListScreen(
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var isRefreshing by remember { mutableStateOf(false) }
+    var showFilterMenu by remember { mutableStateOf(false) }
 
     Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
                 title = { Text("Incidents") },
@@ -46,6 +51,51 @@ fun IncidentListScreen(
                             modifier = Modifier.size(24.dp).padding(end = 4.dp),
                             strokeWidth = 2.dp
                         )
+                    }
+                    Box {
+                        IconButton(onClick = { showFilterMenu = true }) {
+                            Icon(
+                                imageVector = if (uiState.activeFilter == IncidentFilter.ALL) {
+                                    Icons.Default.FilterList
+                                } else {
+                                    Icons.Default.FilterList
+                                },
+                                contentDescription = "Filter by severity"
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = showFilterMenu,
+                            onDismissRequest = { showFilterMenu = false }
+                        ) {
+                            IncidentFilter.values().forEach { filter ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            when (filter) {
+                                                IncidentFilter.ALL -> "All"
+                                                IncidentFilter.CRITICAL -> "Critical"
+                                                IncidentFilter.WARNING -> "Warning"
+                                            }
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        if (uiState.activeFilter == filter) {
+                                            Icon(Icons.Default.Check, contentDescription = null)
+                                        } else {
+                                            when (filter) {
+                                                IncidentFilter.ALL -> Unit
+                                                IncidentFilter.CRITICAL -> Icon(Icons.Default.Error, contentDescription = null)
+                                                IncidentFilter.WARNING -> Icon(Icons.Default.Warning, contentDescription = null)
+                                            }
+                                        }
+                                    },
+                                    onClick = {
+                                        viewModel.setFilter(filter)
+                                        showFilterMenu = false
+                                    }
+                                )
+                            }
+                        }
                     }
                 }
             )
@@ -63,45 +113,6 @@ fun IncidentListScreen(
                 .padding(paddingValues)
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
-                ConnectionStatusBanner(state = connectionState)
-
-                // Filter chips
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    IncidentFilter.values().forEach { filter ->
-                        FilterChip(
-                            selected = uiState.activeFilter == filter,
-                            onClick = { viewModel.setFilter(filter) },
-                            label = {
-                                val label = when (filter) {
-                                    IncidentFilter.ALL -> {
-                                        val openCount = uiState.incidents.count {
-                                            it.status == IncidentStatus.OPEN
-                                        }
-                                        if (openCount > 0) "All ($openCount)" else "All"
-                                    }
-                                    IncidentFilter.CRITICAL -> "Critical"
-                                    IncidentFilter.WARNING -> "Warning"
-                                }
-                                Text(label)
-                            },
-                            leadingIcon = when (filter) {
-                                IncidentFilter.ALL -> null
-                                IncidentFilter.CRITICAL -> {
-                                    { Icon(Icons.Default.Error, contentDescription = null, modifier = Modifier.size(16.dp)) }
-                                }
-                                IncidentFilter.WARNING -> {
-                                    { Icon(Icons.Default.Warning, contentDescription = null, modifier = Modifier.size(16.dp)) }
-                                }
-                            }
-                        )
-                    }
-                }
-
                 // Error
                 uiState.error?.let { error ->
                     Card(
@@ -126,15 +137,15 @@ fun IncidentListScreen(
                         contentAlignment = Alignment.Center
                     ) {
                         EmptyState(
-                            title = "No incidents",
-                            subtitle = "All clear — no incidents to report",
+                            title = if (uiState.activeFilter == IncidentFilter.ALL) "No Incidents" else "No ${uiState.activeFilter.name.lowercase().replaceFirstChar { it.uppercase() }} Incidents",
+                            subtitle = uiState.error ?: "All clear — no incidents to report.",
                             icon = Icons.Default.CheckCircle
                         )
                     }
                 } else {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(vertical = 4.dp)
+                        contentPadding = PaddingValues(vertical = 8.dp)
                     ) {
                         items(
                             items = uiState.filteredIncidents,
@@ -158,7 +169,8 @@ private fun IncidentListItem(incident: Incident, onClick: () -> Unit) {
     ListItem(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp),
         headlineContent = {
             Text(
                 text = incident.title,
@@ -185,8 +197,6 @@ private fun IncidentListItem(incident: Incident, onClick: () -> Unit) {
         },
         trailingContent = {
             Column(horizontalAlignment = Alignment.End) {
-                SeverityBadge(severity = incident.severity)
-                Spacer(modifier = Modifier.height(4.dp))
                 if (incident.status != IncidentStatus.OPEN) {
                     Text(
                         text = incident.status.name.lowercase().replaceFirstChar { it.uppercase() },
@@ -195,7 +205,8 @@ private fun IncidentListItem(incident: Incident, onClick: () -> Unit) {
                     )
                 }
             }
-        }
+        },
+        colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.surface)
     )
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 }

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/settings/SettingsScreen.kt
@@ -8,12 +8,15 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.CloudDone
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -32,13 +35,6 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = viewModel()
 ) {
     val gatewayRepo = appViewModel.gatewayRepository
-    val approvalRepo by appViewModel.approvalRepository.collectAsStateWithLifecycle()
-    val pendingApprovals by remember(approvalRepo) {
-        derivedStateOf { approvalRepo?.pendingApprovals?.value ?: emptyList() }
-    }
-    val connectionState by appViewModel.connectionState.collectAsStateWithLifecycle()
-    val lastGatewaySignal by appViewModel.lastGatewaySignal.collectAsStateWithLifecycle()
-    val gatewaySignalSummary by appViewModel.gatewaySignalSummary.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.setRepository(gatewayRepo)
@@ -49,14 +45,12 @@ fun SettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Settings") }
-            )
-        },
-        floatingActionButton = {
-            ExtendedFloatingActionButton(
-                onClick = onAddGateway,
-                icon = { Icon(Icons.Default.Add, contentDescription = null) },
-                text = { Text("Add Gateway") }
+                title = { Text("Gateways") },
+                actions = {
+                    IconButton(onClick = onAddGateway) {
+                        Icon(Icons.Default.Add, contentDescription = "Add Gateway")
+                    }
+                }
             )
         }
     ) { paddingValues ->
@@ -64,83 +58,26 @@ fun SettingsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
-            contentPadding = PaddingValues(bottom = 88.dp)
+            contentPadding = PaddingValues(bottom = 24.dp)
         ) {
-            // Connection status
-            item {
-                ConnectionStatusBanner(
-                    state = connectionState,
-                    lastSignalAt = lastGatewaySignal,
-                    signalSummary = gatewaySignalSummary
-                )
-            }
-
-            // Upgrade to Pro CTA
-            item {
-                UpgradeToProCard(onClick = onUpgradeClick)
-            }
-
-            // Pending approvals section
-            if (pendingApprovals.isNotEmpty()) {
-                item {
-                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
-                        Text(
-                            text = "Pending Approvals",
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.SemiBold,
-                            modifier = Modifier.padding(bottom = 8.dp)
-                        )
-                    }
-                }
-                items(pendingApprovals, key = { "approval_${it.id}" }) { approval ->
-                    ListItem(
-                        modifier = Modifier.clickable { onApprovalClick(approval.id) },
-                        headlineContent = { Text(approval.title, style = MaterialTheme.typography.bodyMedium) },
-                        supportingContent = {
-                            Text(
-                                text = "${approval.agentName} • ${approval.actionType.name.lowercase().replace('_', ' ')}",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        },
-                        leadingContent = {
-                            Icon(
-                                Icons.Default.Warning,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.error
-                            )
-                        },
-                        trailingContent = {
-                            Icon(Icons.Default.ChevronRight, contentDescription = null)
-                        },
-                        colors = ListItemDefaults.colors(
-                            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f)
-                        )
-                    )
-                    HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                }
-                item { Spacer(modifier = Modifier.height(8.dp)) }
-            }
-
-            // Gateways section header
-            item {
-                Text(
-                    text = "Gateways",
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
-                )
-            }
-
             if (uiState.gateways.isEmpty()) {
                 item {
-                    EmptyState(
-                        title = "No gateways",
-                        subtitle = "Tap Add Gateway to connect to an OpenClaw gateway",
-                        icon = Icons.Default.Cloud,
-                        modifier = Modifier.padding(vertical = 32.dp)
-                    )
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        EmptyState(
+                            title = "No Gateways",
+                            subtitle = "Add a gateway to connect to your OpenClaw instance.",
+                            icon = Icons.Default.Cloud,
+                            modifier = Modifier.padding(bottom = 16.dp)
+                        )
+                        Button(onClick = onAddGateway) {
+                            Text("Add Gateway")
+                        }
+                    }
                 }
             } else {
                 items(uiState.gateways, key = { it.id }) { gateway ->
@@ -157,7 +94,6 @@ fun SettingsScreen(
                 }
             }
 
-            // App info section
             item {
                 HorizontalDivider(modifier = Modifier.padding(top = 16.dp))
                 Column(modifier = Modifier.padding(16.dp)) {
@@ -226,50 +162,6 @@ private fun SwipeToDismissGatewayItem(
             isActive = isActive,
             onSetActive = onSetActive
         )
-    }
-}
-
-@Composable
-private fun UpgradeToProCard(onClick: () -> Unit) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-            .clickable(onClick = onClick),
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer
-        )
-    ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Icon(
-                imageVector = Icons.Default.Star,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onPrimaryContainer
-            )
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = "Upgrade to OpenClaw Pro",
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-                Text(
-                    text = "DevOps integrations, advanced analytics, unlimited agents, and more.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
-            Icon(
-                imageVector = Icons.Default.ChevronRight,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onPrimaryContainer
-            )
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- simplify Android Incidents and Bridges tabs to match the iOS grouped-list model
- remove Android-only screen banners and filter chips where iOS uses toolbar actions
- collapse Settings back toward the iOS gateway-list structure

## Verification
- ./gradlew :app:assembleDebug
- ./gradlew :app:testDebugUnitTest
- ./gradlew :app:lintDebug