### PR TITLE
feat: add agent governance audit state

### DIFF
--- a/android/app/src/main/java/com/openclaw/console/data/model/ApprovalRequest.kt
+++ b/android/app/src/main/java/com/openclaw/console/data/model/ApprovalRequest.kt
@@ -2,6 +2,7 @@ package com.openclaw.console.data.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 @Serializable
 enum class ActionType {
@@ -10,7 +11,15 @@ enum class ActionType {
     @SerialName("config_change") CONFIG_CHANGE,
     @SerialName("key_rotation") KEY_ROTATION,
     @SerialName("trade_execution") TRADE_EXECUTION,
-    @SerialName("destructive") DESTRUCTIVE
+    @SerialName("destructive") DESTRUCTIVE,
+    @SerialName("ask_root_cause") ASK_ROOT_CAUSE,
+    @SerialName("propose_fix") PROPOSE_FIX,
+    @SerialName("acknowledge") ACKNOWLEDGE,
+    @SerialName("git_commit") GIT_COMMIT,
+    @SerialName("git_merge") GIT_MERGE,
+    @SerialName("git_push") GIT_PUSH,
+    @SerialName("agent_skill_install") AGENT_SKILL_INSTALL,
+    @SerialName("agent_rollback") AGENT_ROLLBACK
 }
 
 @Serializable
@@ -30,7 +39,18 @@ data class ApprovalContext(
     val service: String = "",
     val environment: String = "",
     val repository: String = "",
-    @SerialName("risk_level") val riskLevel: RiskLevel = RiskLevel.HIGH
+    @SerialName("risk_level") val riskLevel: RiskLevel = RiskLevel.HIGH,
+    @SerialName("git_operation") val gitOperation: GitOperation? = null
+)
+
+@Serializable
+data class GitOperation(
+    @SerialName("operation_type") val operationType: String,
+    @SerialName("branch_from") val branchFrom: String? = null,
+    @SerialName("branch_to") val branchTo: String? = null,
+    @SerialName("commit_message") val commitMessage: String? = null,
+    @SerialName("file_changes") val fileChanges: List<String>? = null,
+    @SerialName("diff_summary") val diffSummary: String? = null
 )
 
 @Serializable
@@ -53,4 +73,76 @@ data class ApprovalResponse(
     val decision: ApprovalDecision,
     @SerialName("biometric_verified") val biometricVerified: Boolean,
     @SerialName("responded_at") val respondedAt: String
+)
+
+@Serializable
+enum class AgentPlanStepStatus {
+    @SerialName("pending") PENDING,
+    @SerialName("running") RUNNING,
+    @SerialName("done") DONE,
+    @SerialName("blocked") BLOCKED,
+    @SerialName("skipped") SKIPPED
+}
+
+@Serializable
+data class AgentPlanStep(
+    val id: String,
+    @SerialName("agent_id") val agentId: String,
+    val title: String,
+    val details: String,
+    val status: AgentPlanStepStatus,
+    val owner: String? = null,
+    val evidence: List<ResourceLink> = emptyList(),
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String
+)
+
+@Serializable
+data class EnvironmentObservation(
+    val id: String,
+    @SerialName("agent_id") val agentId: String,
+    val source: String,
+    val summary: String,
+    @SerialName("observed_at") val observedAt: String,
+    val metadata: JsonObject? = null
+)
+
+@Serializable
+data class RollbackPoint(
+    val id: String,
+    @SerialName("agent_id") val agentId: String,
+    @SerialName("action_type") val actionType: ActionType,
+    val title: String,
+    val description: String,
+    val command: String,
+    @SerialName("created_at") val createdAt: String,
+    val metadata: JsonObject? = null
+)
+
+@Serializable
+data class GovernanceEvent(
+    val id: String,
+    @SerialName("agent_id") val agentId: String,
+    val type: String,
+    val title: String,
+    val summary: String,
+    @SerialName("created_at") val createdAt: String,
+    val actor: String,
+    @SerialName("risk_level") val riskLevel: RiskLevel? = null,
+    @SerialName("approval_id") val approvalId: String? = null,
+    @SerialName("task_id") val taskId: String? = null,
+    @SerialName("incident_id") val incidentId: String? = null,
+    @SerialName("rollback_point_id") val rollbackPointId: String? = null,
+    val metadata: JsonObject? = null
+)
+
+@Serializable
+data class AgentGovernanceState(
+    @SerialName("agent_id") val agentId: String,
+    @SerialName("current_objective") val currentObjective: String? = null,
+    @SerialName("objective_updated_at") val objectiveUpdatedAt: String? = null,
+    val plan: List<AgentPlanStep> = emptyList(),
+    val environment: List<EnvironmentObservation> = emptyList(),
+    @SerialName("rollback_points") val rollbackPoints: List<RollbackPoint> = emptyList(),
+    val events: List<GovernanceEvent> = emptyList()
 )

--- a/android/app/src/main/java/com/openclaw/console/data/network/ApiService.kt
+++ b/android/app/src/main/java/com/openclaw/console/data/network/ApiService.kt
@@ -105,6 +105,27 @@ class ApiService(
         }
     }
 
+    suspend fun getAgentGovernance(agentId: String): Result<AgentGovernanceState> {
+        val request = Request.Builder()
+            .url("${normalizedBase()}/api/agents/$agentId/governance")
+            .get()
+            .build()
+        return executeRequest(request) { body ->
+            json.decodeFromString<AgentGovernanceState>(body)
+        }
+    }
+
+    suspend fun getGovernanceEvents(agentId: String? = null, limit: Int = 100): Result<List<GovernanceEvent>> {
+        val agentQuery = agentId?.let { "&agent_id=$it" } ?: ""
+        val request = Request.Builder()
+            .url("${normalizedBase()}/api/governance/events?limit=$limit$agentQuery")
+            .get()
+            .build()
+        return executeRequest(request) { body ->
+            json.decodeFromString<List<GovernanceEvent>>(body)
+        }
+    }
+
     suspend fun getIncidents(): Result<List<Incident>> {
         val request = Request.Builder()
             .url("${normalizedBase()}/api/incidents")

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/approvals/ApprovalDetailScreen.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/approvals/ApprovalDetailScreen.kt
@@ -359,6 +359,14 @@ private fun ActionTypeBadge(actionType: ActionType) {
         ActionType.KEY_ROTATION -> "Key Rotation" to Icons.Default.VpnKey
         ActionType.TRADE_EXECUTION -> "Trade Execution" to Icons.Default.TrendingUp
         ActionType.DESTRUCTIVE -> "Destructive" to Icons.Default.DeleteForever
+        ActionType.ASK_ROOT_CAUSE -> "Root Cause" to Icons.Default.Warning
+        ActionType.PROPOSE_FIX -> "Propose Fix" to Icons.Default.Build
+        ActionType.ACKNOWLEDGE -> "Acknowledge" to Icons.Default.CheckCircle
+        ActionType.GIT_COMMIT -> "Git Commit" to Icons.Default.Code
+        ActionType.GIT_MERGE -> "Git Merge" to Icons.Default.Code
+        ActionType.GIT_PUSH -> "Git Push" to Icons.Default.Code
+        ActionType.AGENT_SKILL_INSTALL -> "Install Skill" to Icons.Default.Build
+        ActionType.AGENT_ROLLBACK -> "Agent Rollback" to Icons.Default.Dangerous
     }
     val color = Color(0xFFE97C00)
 

--- a/ios/OpenClawConsole/OpenClawConsole/Models/ApprovalRequest.swift
+++ b/ios/OpenClawConsole/OpenClawConsole/Models/ApprovalRequest.swift
@@ -14,6 +14,14 @@ enum ApprovalActionType: String, Codable, CaseIterable {
     case keyRotation = "key_rotation"
     case tradeExecution = "trade_execution"
     case destructive
+    case askRootCause = "ask_root_cause"
+    case proposeFix = "propose_fix"
+    case acknowledge
+    case gitCommit = "git_commit"
+    case gitMerge = "git_merge"
+    case gitPush = "git_push"
+    case agentSkillInstall = "agent_skill_install"
+    case agentRollback = "agent_rollback"
 
     var displayName: String {
         switch self {
@@ -23,6 +31,14 @@ enum ApprovalActionType: String, Codable, CaseIterable {
         case .keyRotation: return "Key Rotation"
         case .tradeExecution: return "Trade Execution"
         case .destructive: return "Destructive Action"
+        case .askRootCause: return "Root Cause"
+        case .proposeFix: return "Propose Fix"
+        case .acknowledge: return "Acknowledge"
+        case .gitCommit: return "Git Commit"
+        case .gitMerge: return "Git Merge"
+        case .gitPush: return "Git Push"
+        case .agentSkillInstall: return "Install Skill"
+        case .agentRollback: return "Agent Rollback"
         }
     }
 
@@ -34,6 +50,14 @@ enum ApprovalActionType: String, Codable, CaseIterable {
         case .keyRotation: return "key"
         case .tradeExecution: return "chart.line.uptrend.xyaxis"
         case .destructive: return "trash"
+        case .askRootCause: return "questionmark.circle"
+        case .proposeFix: return "wrench.and.screwdriver"
+        case .acknowledge: return "checkmark.circle"
+        case .gitCommit: return "arrow.triangle.branch"
+        case .gitMerge: return "arrow.triangle.merge"
+        case .gitPush: return "arrow.up.doc"
+        case .agentSkillInstall: return "square.and.arrow.down"
+        case .agentRollback: return "arrow.uturn.backward"
         }
     }
 }
@@ -61,17 +85,37 @@ enum RiskLevel: String, Codable {
 
 // MARK: - Approval Context
 
+struct GitOperation: Codable, Hashable {
+    let operationType: String
+    let branchFrom: String?
+    let branchTo: String?
+    let commitMessage: String?
+    let fileChanges: [String]?
+    let diffSummary: String?
+
+    enum CodingKeys: String, CodingKey {
+        case operationType = "operation_type"
+        case branchFrom = "branch_from"
+        case branchTo = "branch_to"
+        case commitMessage = "commit_message"
+        case fileChanges = "file_changes"
+        case diffSummary = "diff_summary"
+    }
+}
+
 struct ApprovalContext: Codable, Hashable {
     let service: String
     let environment: String
     let repository: String
     let riskLevel: RiskLevel
+    let gitOperation: GitOperation?
 
     enum CodingKeys: String, CodingKey {
         case service
         case environment
         case repository
         case riskLevel = "risk_level"
+        case gitOperation = "git_operation"
     }
 }
 
@@ -140,4 +184,124 @@ struct ApprovalResponse: Codable {
 enum ApprovalDecision: String, Codable {
     case approved
     case denied
+}
+
+// MARK: - Governance
+
+enum AgentPlanStepStatus: String, Codable {
+    case pending
+    case running
+    case done
+    case blocked
+    case skipped
+}
+
+struct AgentPlanStep: Codable, Identifiable, Hashable {
+    let id: String
+    let agentId: String
+    let title: String
+    let details: String
+    let status: AgentPlanStepStatus
+    let owner: String?
+    let evidence: [ResourceLink]
+    let createdAt: Date
+    let updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case agentId = "agent_id"
+        case title
+        case details
+        case status
+        case owner
+        case evidence
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+}
+
+struct EnvironmentObservation: Codable, Identifiable, Hashable {
+    let id: String
+    let agentId: String
+    let source: String
+    let summary: String
+    let observedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case agentId = "agent_id"
+        case source
+        case summary
+        case observedAt = "observed_at"
+    }
+}
+
+struct RollbackPoint: Codable, Identifiable, Hashable {
+    let id: String
+    let agentId: String
+    let actionType: ApprovalActionType
+    let title: String
+    let description: String
+    let command: String
+    let createdAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case agentId = "agent_id"
+        case actionType = "action_type"
+        case title
+        case description
+        case command
+        case createdAt = "created_at"
+    }
+}
+
+struct GovernanceEvent: Codable, Identifiable, Hashable {
+    let id: String
+    let agentId: String
+    let type: String
+    let title: String
+    let summary: String
+    let createdAt: Date
+    let actor: String
+    let riskLevel: RiskLevel?
+    let approvalId: String?
+    let taskId: String?
+    let incidentId: String?
+    let rollbackPointId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case agentId = "agent_id"
+        case type
+        case title
+        case summary
+        case createdAt = "created_at"
+        case actor
+        case riskLevel = "risk_level"
+        case approvalId = "approval_id"
+        case taskId = "task_id"
+        case incidentId = "incident_id"
+        case rollbackPointId = "rollback_point_id"
+    }
+}
+
+struct AgentGovernanceState: Codable, Hashable {
+    let agentId: String
+    let currentObjective: String?
+    let objectiveUpdatedAt: Date?
+    let plan: [AgentPlanStep]
+    let environment: [EnvironmentObservation]
+    let rollbackPoints: [RollbackPoint]
+    let events: [GovernanceEvent]
+
+    enum CodingKeys: String, CodingKey {
+        case agentId = "agent_id"
+        case currentObjective = "current_objective"
+        case objectiveUpdatedAt = "objective_updated_at"
+        case plan
+        case environment
+        case rollbackPoints = "rollback_points"
+        case events
+    }
 }

--- a/ios/OpenClawConsole/OpenClawConsole/Services/APIService.swift
+++ b/ios/OpenClawConsole/OpenClawConsole/Services/APIService.swift
@@ -144,6 +144,23 @@ final class APIService {
         try await request(path: "/api/agents/\(agentId)/tasks/\(taskId)")
     }
 
+    // MARK: - Governance
+
+    func fetchGovernance(for agentId: String) async throws -> AgentGovernanceState {
+        try await request(path: "/api/agents/\(agentId)/governance")
+    }
+
+    func fetchGovernanceEvents(agentId: String? = nil, limit: Int = 100) async throws -> [GovernanceEvent] {
+        var components = URLComponents()
+        components.path = "/api/governance/events"
+        var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        if let agentId {
+            queryItems.append(URLQueryItem(name: "agent_id", value: agentId))
+        }
+        components.queryItems = queryItems
+        return try await request(path: components.string ?? "/api/governance/events")
+    }
+
     // MARK: - Incidents
 
     func fetchIncidents() async throws -> [Incident] {

--- a/openclaw-skills/src/config/default.ts
+++ b/openclaw-skills/src/config/default.ts
@@ -43,6 +43,8 @@ export interface GatewayConfig {
   localModelName: string | null;
   /** Local model status probe timeout in milliseconds */
   localModelTimeoutMs: number;
+  /** Append-only JSONL path for governance/audit events */
+  governanceEventLogPath: string;
 }
 
 const DEFAULT_CONFIG: GatewayConfig = {
@@ -65,6 +67,7 @@ const DEFAULT_CONFIG: GatewayConfig = {
   localModelBaseUrl: process.env['OPENCLAW_LOCAL_MODEL_BASE_URL'] ?? process.env['OPENAI_BASE_URL'] ?? null,
   localModelName: process.env['OPENCLAW_LOCAL_MODEL_NAME'] ?? null,
   localModelTimeoutMs: parseInt(process.env['OPENCLAW_LOCAL_MODEL_TIMEOUT_MS'] ?? '2500', 10),
+  governanceEventLogPath: process.env['OPENCLAW_GOVERNANCE_EVENT_LOG'] ?? './data/governance-events.jsonl',
 };
 
 export function isApprovalPolicyPreset(raw: string): raw is ApprovalPolicyPreset {

--- a/openclaw-skills/src/gateway/server.ts
+++ b/openclaw-skills/src/gateway/server.ts
@@ -26,6 +26,9 @@ import type {
   ApprovalResponse,
   RuntimeConfigResponse,
   RuntimeConfigUpdateRequest,
+  ActionType,
+  AgentPlanStepStatus,
+  GovernanceEvent,
 } from '../types/protocol.js';
 import { ERROR_CODES } from '../types/protocol.js';
 import { createBillingRouter } from '../billing/revenuecat.js';
@@ -197,6 +200,114 @@ export function createGatewayServer(
       return;
     }
     res.json(task);
+  });
+
+  // ── Agent Governance ─────────────────────────────────────────────────────
+
+  app.get('/api/agents/:id/governance', auth, (req: Request, res: Response) => {
+    const agentId = String(req.params['id'] ?? '');
+    if (!state.getAgent(agentId)) {
+      res.status(404).json({ error: { code: ERROR_CODES.AGENT_NOT_FOUND, message: 'Agent not found' } });
+      return;
+    }
+    res.json(state.getAgentGovernance(agentId));
+  });
+
+  app.post('/api/agents/:id/governance/objective', auth, async (req: Request, res: Response) => {
+    const agentId = String(req.params['id'] ?? '');
+    if (!state.getAgent(agentId)) {
+      res.status(404).json({ error: { code: ERROR_CODES.AGENT_NOT_FOUND, message: 'Agent not found' } });
+      return;
+    }
+    const objective = typeof req.body?.objective === 'string' ? req.body.objective.trim() : '';
+    if (!objective) {
+      res.status(400).json({ error: { code: 4000, message: 'objective is required' } });
+      return;
+    }
+    res.json(await state.updateAgentObjective(agentId, objective, parseActor(req.body?.actor)));
+  });
+
+  app.post('/api/agents/:id/governance/plan-steps', auth, async (req: Request, res: Response) => {
+    const agentId = String(req.params['id'] ?? '');
+    if (!state.getAgent(agentId)) {
+      res.status(404).json({ error: { code: ERROR_CODES.AGENT_NOT_FOUND, message: 'Agent not found' } });
+      return;
+    }
+    const title = typeof req.body?.title === 'string' ? req.body.title.trim() : '';
+    if (!title) {
+      res.status(400).json({ error: { code: 4000, message: 'title is required' } });
+      return;
+    }
+    const status = req.body?.status === undefined
+      ? undefined
+      : isPlanStepStatus(req.body.status) ? req.body.status : null;
+    if (status === null) {
+      res.status(400).json({ error: { code: 4000, message: 'Invalid plan step status' } });
+      return;
+    }
+    const step = await state.upsertAgentPlanStep({
+      agent_id: agentId,
+      id: typeof req.body?.id === 'string' ? req.body.id : undefined,
+      title,
+      details: typeof req.body?.details === 'string' ? req.body.details : undefined,
+      status,
+      owner: typeof req.body?.owner === 'string' ? req.body.owner : null,
+      evidence: Array.isArray(req.body?.evidence) ? req.body.evidence : undefined,
+      actor: parseActor(req.body?.actor),
+    });
+    res.json(step);
+  });
+
+  app.post('/api/agents/:id/governance/environment-observations', auth, async (req: Request, res: Response) => {
+    const agentId = String(req.params['id'] ?? '');
+    if (!state.getAgent(agentId)) {
+      res.status(404).json({ error: { code: ERROR_CODES.AGENT_NOT_FOUND, message: 'Agent not found' } });
+      return;
+    }
+    const source = typeof req.body?.source === 'string' ? req.body.source.trim() : '';
+    const summary = typeof req.body?.summary === 'string' ? req.body.summary.trim() : '';
+    if (!source || !summary) {
+      res.status(400).json({ error: { code: 4000, message: 'source and summary are required' } });
+      return;
+    }
+    res.json(await state.recordEnvironmentObservation({
+      agent_id: agentId,
+      source,
+      summary,
+      metadata: typeof req.body?.metadata === 'object' && req.body.metadata !== null ? req.body.metadata : undefined,
+      actor: parseActor(req.body?.actor),
+    }));
+  });
+
+  app.post('/api/agents/:id/governance/rollback-points', auth, async (req: Request, res: Response) => {
+    const agentId = String(req.params['id'] ?? '');
+    if (!state.getAgent(agentId)) {
+      res.status(404).json({ error: { code: ERROR_CODES.AGENT_NOT_FOUND, message: 'Agent not found' } });
+      return;
+    }
+    const actionType = req.body?.action_type;
+    const title = typeof req.body?.title === 'string' ? req.body.title.trim() : '';
+    const description = typeof req.body?.description === 'string' ? req.body.description.trim() : '';
+    const command = typeof req.body?.command === 'string' ? req.body.command.trim() : '';
+    if (!isActionType(actionType) || !title || !description || !command) {
+      res.status(400).json({ error: { code: 4000, message: 'action_type, title, description, and command are required' } });
+      return;
+    }
+    res.json(await state.addRollbackPoint({
+      agent_id: agentId,
+      action_type: actionType,
+      title,
+      description,
+      command,
+      metadata: typeof req.body?.metadata === 'object' && req.body.metadata !== null ? req.body.metadata : undefined,
+      actor: parseActor(req.body?.actor),
+    }));
+  });
+
+  app.get('/api/governance/events', auth, (req: Request, res: Response) => {
+    const agentId = typeof req.query['agent_id'] === 'string' ? req.query['agent_id'] : undefined;
+    const limitRaw = typeof req.query['limit'] === 'string' ? Number.parseInt(req.query['limit'], 10) : 100;
+    res.json(state.listGovernanceEvents(agentId, Number.isFinite(limitRaw) ? limitRaw : 100));
   });
 
   // ── Incidents ─────────────────────────────────────────────────────────────
@@ -386,6 +497,33 @@ export function createGatewayServer(
           else resolve();
         });
       });
-    },
-  };
-}
+      },
+    };
+  }
+
+  function isActionType(value: unknown): value is ActionType {
+    return typeof value === 'string' && [
+      'deploy',
+      'shell_command',
+      'config_change',
+      'key_rotation',
+      'trade_execution',
+      'destructive',
+      'ask_root_cause',
+      'propose_fix',
+      'acknowledge',
+      'git_commit',
+      'git_merge',
+      'git_push',
+      'agent_skill_install',
+      'agent_rollback',
+    ].includes(value);
+  }
+
+  function isPlanStepStatus(value: unknown): value is AgentPlanStepStatus {
+    return typeof value === 'string' && ['pending', 'running', 'done', 'blocked', 'skipped'].includes(value);
+  }
+
+  function parseActor(value: unknown): GovernanceEvent['actor'] {
+    return value === 'human' || value === 'gateway' || value === 'policy' ? value : 'agent';
+  }

--- a/openclaw-skills/src/gateway/state-interface.ts
+++ b/openclaw-skills/src/gateway/state-interface.ts
@@ -14,6 +14,13 @@ import type {
   ApprovalResponse,
   BridgeSession,
   RecurringTask,
+  AgentGovernanceState,
+  AgentPlanStep,
+  AgentPlanStepStatus,
+  EnvironmentObservation,
+  GovernanceEvent,
+  GovernanceEventType,
+  RollbackPoint,
 } from '../types/protocol.js';
 
 /**
@@ -67,4 +74,47 @@ export interface IStateManager {
 
   upsertRecurringTask?(task: RecurringTask): Promise<RecurringTask>;
   listRecurringTasks?(): Promise<RecurringTask[]> | RecurringTask[];
+
+  getAgentGovernance?(agentId: string): Promise<AgentGovernanceState> | AgentGovernanceState;
+  updateAgentObjective?(agentId: string, objective: string, actor?: GovernanceEvent['actor']): Promise<AgentGovernanceState>;
+  upsertAgentPlanStep?(params: {
+    agent_id: string;
+    id?: string;
+    title: string;
+    details?: string;
+    status?: AgentPlanStepStatus;
+    owner?: string | null;
+    evidence?: AgentPlanStep['evidence'];
+    actor?: GovernanceEvent['actor'];
+  }): Promise<AgentPlanStep>;
+  recordEnvironmentObservation?(params: {
+    agent_id: string;
+    source: string;
+    summary: string;
+    metadata?: Record<string, unknown>;
+    actor?: GovernanceEvent['actor'];
+  }): Promise<EnvironmentObservation>;
+  addRollbackPoint?(params: {
+    agent_id: string;
+    action_type: ActionType;
+    title: string;
+    description: string;
+    command: string;
+    metadata?: Record<string, unknown>;
+    actor?: GovernanceEvent['actor'];
+  }): Promise<RollbackPoint>;
+  recordGovernanceEvent?(params: {
+    agent_id: string;
+    type: GovernanceEventType;
+    title: string;
+    summary: string;
+    actor: GovernanceEvent['actor'];
+    risk_level?: GovernanceEvent['risk_level'];
+    approval_id?: string;
+    task_id?: string;
+    incident_id?: string;
+    rollback_point_id?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<GovernanceEvent>;
+  listGovernanceEvents?(agentId?: string, limit?: number): Promise<GovernanceEvent[]> | GovernanceEvent[];
 }

--- a/openclaw-skills/src/gateway/state.ts
+++ b/openclaw-skills/src/gateway/state.ts
@@ -7,6 +7,8 @@
  */
 
 import EventEmitter from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 import type {
   Agent,
@@ -24,6 +26,14 @@ import type {
   ResourceLink,
   BridgeSession,
   RecurringTask,
+  AgentGovernanceState,
+  AgentPlanStep,
+  AgentPlanStepStatus,
+  EnvironmentObservation,
+  GovernanceEvent,
+  GovernanceEventType,
+  RollbackPoint,
+  RiskLevel,
 } from '../types/protocol.js';
 import type { IStateManager } from './state-interface.js';
 
@@ -42,6 +52,7 @@ export interface StateEvents {
   bridge_session_new: [session: BridgeSession];
   bridge_session_update: [session: BridgeSession];
   recurring_task_updated: [task: RecurringTask];
+  governance_event: [event: GovernanceEvent];
 }
 
 export type StateEventName = keyof StateEvents;
@@ -72,6 +83,10 @@ interface PendingApproval {
   reject: (reason: Error) => void;
 }
 
+export interface StateManagerOptions {
+  governanceEventLogPath?: string | null;
+}
+
 // ── StateManager ─────────────────────────────────────────────────────────────
 
 /** Centralized in-memory store with event emission on mutations. */
@@ -84,6 +99,123 @@ export class StateManager implements IStateManager {
   private approvals: Map<string, PendingApproval> = new Map();
   private bridgeSessions: Map<string, BridgeSession> = new Map();
   private recurringTasks: Map<string, RecurringTask> = new Map();
+  private governanceStates: Map<string, AgentGovernanceState> = new Map();
+  private governanceEvents: GovernanceEvent[] = [];
+  private readonly governanceEventLogPath: string | null;
+
+  public constructor(options: StateManagerOptions = {}) {
+    this.governanceEventLogPath = options.governanceEventLogPath ?? null;
+    this.loadGovernanceEvents();
+  }
+
+  private governanceFor(agentId: string): AgentGovernanceState {
+    let state = this.governanceStates.get(agentId);
+    if (!state) {
+      state = {
+        agent_id: agentId,
+        current_objective: null,
+        objective_updated_at: null,
+        plan: [],
+        environment: [],
+        rollback_points: [],
+        events: [],
+      };
+      this.governanceStates.set(agentId, state);
+    }
+    return state;
+  }
+
+  private cloneGovernanceState(agentId: string): AgentGovernanceState {
+    const state = this.governanceFor(agentId);
+    return {
+      agent_id: state.agent_id,
+      current_objective: state.current_objective,
+      objective_updated_at: state.objective_updated_at,
+      plan: state.plan.map((step) => ({ ...step, evidence: [...step.evidence] })),
+      environment: state.environment.map((observation) => ({ ...observation, metadata: { ...observation.metadata } })),
+      rollback_points: state.rollback_points.map((point) => ({ ...point, metadata: { ...point.metadata } })),
+      events: state.events.map((event) => ({ ...event, metadata: { ...event.metadata } })),
+    };
+  }
+
+  private loadGovernanceEvents(): void {
+    if (!this.governanceEventLogPath || !fs.existsSync(this.governanceEventLogPath)) return;
+
+    const contents = fs.readFileSync(this.governanceEventLogPath, 'utf8');
+    for (const line of contents.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const event = JSON.parse(trimmed) as GovernanceEvent;
+        this.applyGovernanceEvent(event, false);
+      } catch (err) {
+        console.warn('[state] Skipping invalid governance event log line:', err);
+      }
+    }
+  }
+
+  private persistGovernanceEvent(event: GovernanceEvent): void {
+    if (!this.governanceEventLogPath) return;
+    try {
+      fs.mkdirSync(path.dirname(this.governanceEventLogPath), { recursive: true });
+      fs.appendFileSync(this.governanceEventLogPath, `${JSON.stringify(event)}\n`, 'utf8');
+    } catch (err) {
+      console.warn('[state] Failed to persist governance event:', err);
+    }
+  }
+
+  private applyGovernanceEvent(event: GovernanceEvent, emit: boolean): GovernanceEvent {
+    this.governanceEvents.push(event);
+    const state = this.governanceFor(event.agent_id);
+
+    switch (event.type) {
+      case 'agent_objective_updated':
+        if (typeof event.metadata['objective'] === 'string') {
+          state.current_objective = event.metadata['objective'];
+          state.objective_updated_at = event.created_at;
+        }
+        break;
+      case 'agent_plan_step_upserted': {
+        const step = event.metadata['plan_step'] as AgentPlanStep | undefined;
+        if (step?.id) {
+          const index = state.plan.findIndex((item) => item.id === step.id);
+          if (index >= 0) {
+            state.plan[index] = step;
+          } else {
+            state.plan.push(step);
+          }
+        }
+        break;
+      }
+      case 'environment_observed': {
+        const observation = event.metadata['observation'] as EnvironmentObservation | undefined;
+        if (observation?.id && !state.environment.some((item) => item.id === observation.id)) {
+          state.environment.push(observation);
+          state.environment = state.environment.slice(-100);
+        }
+        break;
+      }
+      case 'rollback_point_added': {
+        const point = event.metadata['rollback_point'] as RollbackPoint | undefined;
+        if (point?.id && !state.rollback_points.some((item) => item.id === point.id)) {
+          state.rollback_points.push(point);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    state.events.push(event);
+    if (state.events.length > 250) {
+      state.events = state.events.slice(-250);
+    }
+    this.governanceStates.set(event.agent_id, state);
+    if (emit) {
+      this.events.emit('governance_event', event);
+    }
+    return event;
+  }
 
   // ── Agent ─────────────────────────────────────────────────────────────────
 
@@ -156,6 +288,15 @@ export class StateManager implements IStateManager {
     };
     this.tasks.set(task.id, task);
     this.events.emit('task_created', task);
+    await this.recordGovernanceEvent({
+      agent_id: params.agent_id,
+      type: 'task_state_changed',
+      title: task.title,
+      summary: 'Task queued',
+      actor: 'gateway',
+      task_id: task.id,
+      metadata: { status: task.status },
+    });
     this.recomputeAgentCounters(params.agent_id);
     return task;
   }
@@ -170,6 +311,15 @@ export class StateManager implements IStateManager {
     task.updated_at = new Date().toISOString();
     this.tasks.set(taskId, task);
     this.events.emit('task_updated', task);
+    await this.recordGovernanceEvent({
+      agent_id: task.agent_id,
+      type: 'task_state_changed',
+      title: task.title,
+      summary: `Task ${status}`,
+      actor: 'gateway',
+      task_id: task.id,
+      metadata: { status },
+    });
     this.recomputeAgentCounters(task.agent_id);
     return task;
   }
@@ -240,6 +390,15 @@ export class StateManager implements IStateManager {
     };
     this.incidents.set(incident.id, incident);
     this.events.emit('incident_created', incident);
+    await this.recordGovernanceEvent({
+      agent_id: params.agent_id,
+      type: 'incident_state_changed',
+      title: params.title,
+      summary: `Incident opened: ${params.severity}`,
+      actor: 'gateway',
+      incident_id: incident.id,
+      metadata: { status: incident.status, severity: params.severity },
+    });
     return incident;
   }
 
@@ -253,6 +412,15 @@ export class StateManager implements IStateManager {
     incident.updated_at = new Date().toISOString();
     this.incidents.set(incidentId, incident);
     this.events.emit('incident_updated', incident);
+    await this.recordGovernanceEvent({
+      agent_id: incident.agent_id,
+      type: 'incident_state_changed',
+      title: incident.title,
+      summary: `Incident ${status}`,
+      actor: 'gateway',
+      incident_id: incident.id,
+      metadata: { status },
+    });
     return incident;
   }
 
@@ -298,6 +466,180 @@ export class StateManager implements IStateManager {
     return Array.from(this.recurringTasks.values());
   }
 
+  // ── Governance ───────────────────────────────────────────────────────────
+
+  public getAgentGovernance(agentId: string): AgentGovernanceState {
+    return this.cloneGovernanceState(agentId);
+  }
+
+  public async updateAgentObjective(
+    agentId: string,
+    objective: string,
+    actor: GovernanceEvent['actor'] = 'agent',
+  ): Promise<AgentGovernanceState> {
+    const now = new Date().toISOString();
+    const state = this.governanceFor(agentId);
+    state.current_objective = objective;
+    state.objective_updated_at = now;
+    this.governanceStates.set(agentId, state);
+    await this.recordGovernanceEvent({
+      agent_id: agentId,
+      type: 'agent_objective_updated',
+      title: 'Agent objective updated',
+      summary: objective,
+      actor,
+      metadata: { objective },
+    });
+    return this.cloneGovernanceState(agentId);
+  }
+
+  public async upsertAgentPlanStep(params: {
+    agent_id: string;
+    id?: string;
+    title: string;
+    details?: string;
+    status?: AgentPlanStepStatus;
+    owner?: string | null;
+    evidence?: AgentPlanStep['evidence'];
+    actor?: GovernanceEvent['actor'];
+  }): Promise<AgentPlanStep> {
+    const now = new Date().toISOString();
+    const state = this.governanceFor(params.agent_id);
+    const existingIndex = params.id ? state.plan.findIndex((step) => step.id === params.id) : -1;
+    const existing = existingIndex >= 0 ? state.plan[existingIndex] : null;
+    const step: AgentPlanStep = {
+      id: existing?.id ?? params.id ?? uuidv4(),
+      agent_id: params.agent_id,
+      title: params.title,
+      details: params.details ?? existing?.details ?? '',
+      status: params.status ?? existing?.status ?? 'pending',
+      owner: params.owner ?? existing?.owner ?? null,
+      evidence: params.evidence ?? existing?.evidence ?? [],
+      created_at: existing?.created_at ?? now,
+      updated_at: now,
+    };
+
+    if (existingIndex >= 0) {
+      state.plan[existingIndex] = step;
+    } else {
+      state.plan.push(step);
+    }
+    this.governanceStates.set(params.agent_id, state);
+    await this.recordGovernanceEvent({
+      agent_id: params.agent_id,
+      type: 'agent_plan_step_upserted',
+      title: step.title,
+      summary: `Plan step is ${step.status}`,
+      actor: params.actor ?? 'agent',
+      metadata: { plan_step: step, plan_step_id: step.id, status: step.status, owner: step.owner },
+    });
+    return step;
+  }
+
+  public async recordEnvironmentObservation(params: {
+    agent_id: string;
+    source: string;
+    summary: string;
+    metadata?: Record<string, unknown>;
+    actor?: GovernanceEvent['actor'];
+  }): Promise<EnvironmentObservation> {
+    const observation: EnvironmentObservation = {
+      id: uuidv4(),
+      agent_id: params.agent_id,
+      source: params.source,
+      summary: params.summary,
+      observed_at: new Date().toISOString(),
+      metadata: params.metadata ?? {},
+    };
+    const state = this.governanceFor(params.agent_id);
+    state.environment.push(observation);
+    state.environment = state.environment.slice(-100);
+    this.governanceStates.set(params.agent_id, state);
+    await this.recordGovernanceEvent({
+      agent_id: params.agent_id,
+      type: 'environment_observed',
+      title: params.source,
+      summary: params.summary,
+      actor: params.actor ?? 'agent',
+      metadata: { observation, observation_id: observation.id, ...observation.metadata },
+    });
+    return observation;
+  }
+
+  public async addRollbackPoint(params: {
+    agent_id: string;
+    action_type: ActionType;
+    title: string;
+    description: string;
+    command: string;
+    metadata?: Record<string, unknown>;
+    actor?: GovernanceEvent['actor'];
+  }): Promise<RollbackPoint> {
+    const point: RollbackPoint = {
+      id: uuidv4(),
+      agent_id: params.agent_id,
+      action_type: params.action_type,
+      title: params.title,
+      description: params.description,
+      command: params.command,
+      created_at: new Date().toISOString(),
+      metadata: params.metadata ?? {},
+    };
+    const state = this.governanceFor(params.agent_id);
+    state.rollback_points.push(point);
+    this.governanceStates.set(params.agent_id, state);
+    await this.recordGovernanceEvent({
+      agent_id: params.agent_id,
+      type: 'rollback_point_added',
+      title: params.title,
+      summary: params.description,
+      actor: params.actor ?? 'agent',
+      rollback_point_id: point.id,
+      metadata: { rollback_point: point, action_type: params.action_type, ...point.metadata },
+    });
+    return point;
+  }
+
+  public async recordGovernanceEvent(params: {
+    agent_id: string;
+    type: GovernanceEventType;
+    title: string;
+    summary: string;
+    actor: GovernanceEvent['actor'];
+    risk_level?: RiskLevel;
+    approval_id?: string;
+    task_id?: string;
+    incident_id?: string;
+    rollback_point_id?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<GovernanceEvent> {
+    const event: GovernanceEvent = {
+      id: uuidv4(),
+      agent_id: params.agent_id,
+      type: params.type,
+      title: params.title,
+      summary: params.summary,
+      created_at: new Date().toISOString(),
+      actor: params.actor,
+      risk_level: params.risk_level,
+      approval_id: params.approval_id,
+      task_id: params.task_id,
+      incident_id: params.incident_id,
+      rollback_point_id: params.rollback_point_id,
+      metadata: params.metadata ?? {},
+    };
+    const applied = this.applyGovernanceEvent(event, true);
+    this.persistGovernanceEvent(applied);
+    return applied;
+  }
+
+  public listGovernanceEvents(agentId?: string, limit = 100): GovernanceEvent[] {
+    const events = agentId
+      ? this.governanceEvents.filter((event) => event.agent_id === agentId)
+      : this.governanceEvents;
+    return events.slice(-Math.max(1, Math.min(limit, 500)));
+  }
+
   // ── Approval ──────────────────────────────────────────────────────────────
 
   /**
@@ -313,11 +655,36 @@ export class StateManager implements IStateManager {
         this.approvals.delete(request.id);
         this.recomputeAgentCounters(request.agent_id);
         this.events.emit('approval_expired', request);
+        void this.recordGovernanceEvent({
+          agent_id: request.agent_id,
+          type: 'approval_expired',
+          title: request.title,
+          summary: 'Approval expired without a human decision',
+          actor: 'gateway',
+          risk_level: request.context.risk_level,
+          approval_id: request.id,
+          metadata: { action_type: request.action_type, command: request.command },
+        });
         reject(new Error(`Approval ${request.id} expired`));
       }, timeoutMs);
 
       this.approvals.set(request.id, { request, expiryTimer, resolve, reject });
       this.recomputeAgentCounters(request.agent_id);
+      void this.recordGovernanceEvent({
+        agent_id: request.agent_id,
+        type: 'approval_requested',
+        title: request.title,
+        summary: request.description,
+        actor: 'agent',
+        risk_level: request.context.risk_level,
+        approval_id: request.id,
+        metadata: {
+          action_type: request.action_type,
+          command: request.command,
+          context: request.context,
+          expires_at: request.expires_at,
+        },
+      });
       this.events.emit('approval_created', request);
     });
   }
@@ -334,6 +701,20 @@ export class StateManager implements IStateManager {
     this.approvals.delete(response.approval_id);
     this.recomputeAgentCounters(pending.request.agent_id);
     this.events.emit('approval_responded', response, pending.request);
+    void this.recordGovernanceEvent({
+      agent_id: pending.request.agent_id,
+      type: 'approval_decided',
+      title: pending.request.title,
+      summary: `Approval ${response.decision}`,
+      actor: 'human',
+      risk_level: pending.request.context.risk_level,
+      approval_id: response.approval_id,
+      metadata: {
+        action_type: pending.request.action_type,
+        biometric_verified: response.biometric_verified,
+        responded_at: response.responded_at,
+      },
+    });
     pending.resolve(response);
     return pending.request;
   }

--- a/openclaw-skills/src/gateway/websocket.ts
+++ b/openclaw-skills/src/gateway/websocket.ts
@@ -28,6 +28,7 @@ import type {
   ApprovalResponse,
   BridgeSession,
   RecurringTask,
+  GovernanceEvent,
 } from '../types/protocol.js';
 import { ERROR_CODES } from '../types/protocol.js';
 import type { StateManager } from './state.js';
@@ -139,6 +140,10 @@ export class WebSocketManager {
 
     this.state.events.on('recurring_task_updated', (task: RecurringTask) => {
       this.broadcastToSubscribers(task.agent_id, 'recurring_task_updated', task);
+    });
+
+    this.state.events.on('governance_event', (event: GovernanceEvent) => {
+      this.broadcastToSubscribers(event.agent_id, 'governance_event', event);
     });
   }
 

--- a/openclaw-skills/src/index.ts
+++ b/openclaw-skills/src/index.ts
@@ -24,7 +24,9 @@ async function main(): Promise<void> {
 
   // ── 1. Initialize state ─────────────────────────────────────────────────
 
-  const state = new StateManager();
+  const state = new StateManager({
+    governanceEventLogPath: DEFAULT_CONFIG.governanceEventLogPath,
+  });
 
   // ── 2. Register configured agents ───────────────────────────────────────
 

--- a/openclaw-skills/src/skills/approval-gate.ts
+++ b/openclaw-skills/src/skills/approval-gate.ts
@@ -29,6 +29,13 @@ export interface DangerousActionOptions {
   };
   /** Timeout override in milliseconds (falls back to config default) */
   timeoutMs?: number;
+  /** Optional recovery command shown and stored before/after risky work */
+  rollback?: {
+    title: string;
+    description: string;
+    command: string;
+    metadata?: Record<string, unknown>;
+  };
 }
 
 export interface ApprovalGateResult {
@@ -136,6 +143,22 @@ export class ApprovalGateSkill {
         autoApproved: true,
         policyReason: policy.reason,
       });
+      await this.state.recordGovernanceEvent?.({
+        agent_id: request.agent_id,
+        type: 'approval_decided',
+        title: request.title,
+        summary: `Auto-approved by ${policy.preset}: ${policy.reason}`,
+        actor: 'policy',
+        risk_level: request.context.risk_level,
+        approval_id: request.id,
+        metadata: {
+          action_type: request.action_type,
+          command: request.command,
+          policy_preset: policy.preset,
+          policy_reason: policy.reason,
+        },
+      });
+      await this.storeRollbackPoint(request, options.rollback);
       console.info(`[approval-gate] Auto-approved ${request.id} via ${policy.preset}: ${policy.reason}`);
       return { approved: true, response, timedOut: false };
     }
@@ -157,6 +180,9 @@ export class ApprovalGateSkill {
         console.warn(`[approval-gate] Approval ${request.id} approved but biometric NOT verified — rejecting`);
       }
 
+      if (approved) {
+        await this.storeRollbackPoint(request, options.rollback);
+      }
       console.info(`[approval-gate] Approval ${request.id}: ${approved ? 'APPROVED' : 'DENIED'}`);
       return { approved, response, timedOut: false };
     } catch {
@@ -173,6 +199,25 @@ export class ApprovalGateSkill {
    */
   public getDecisionLog(): ApprovalLogEntry[] {
     return [...this.decisionLog];
+  }
+
+  private async storeRollbackPoint(
+    request: ApprovalRequest,
+    rollback: DangerousActionOptions['rollback'],
+  ): Promise<void> {
+    if (!rollback) return;
+    await this.state.addRollbackPoint?.({
+      agent_id: request.agent_id,
+      action_type: request.action_type,
+      title: rollback.title,
+      description: rollback.description,
+      command: rollback.command,
+      metadata: {
+        approval_id: request.id,
+        ...rollback.metadata,
+      },
+      actor: 'agent',
+    });
   }
 
   /**
@@ -227,7 +272,13 @@ export class ApprovalGateSkill {
         repository,
         riskLevel: environment === 'production' ? 'critical' : 'high',
       },
-    }); // Type cast due to small differences in options naming in protocol
+      rollback: {
+        title: `Rollback ${service} deployment in ${environment}`,
+        description: `Restore ${service} to the previous image or release if version ${version} causes an incident.`,
+        command: `kubectl rollout undo deployment/${service} -n ${environment}`,
+        metadata: { service, version, environment, repository },
+      },
+    });
     return result.approved;
   }
 
@@ -291,6 +342,12 @@ export class ApprovalGateSkill {
           diff_summary: diffSummary,
         },
       },
+      rollback: {
+        title: `Undo commit in ${repository}`,
+        description: `Create a revert commit if "${commitMessage}" needs to be backed out.`,
+        command: 'git revert HEAD',
+        metadata: { repository, commit_message: commitMessage, file_changes: fileChanges },
+      },
     });
     return result.approved;
   }
@@ -330,6 +387,12 @@ export class ApprovalGateSkill {
           diff_summary: diffSummary,
         },
       },
+      rollback: {
+        title: `Rollback merge to ${toBranch}`,
+        description: `Revert the merge from ${fromBranch} into ${toBranch} if validation fails.`,
+        command: 'git revert -m 1 HEAD',
+        metadata: { repository, from_branch: fromBranch, to_branch: toBranch, file_changes: fileChanges },
+      },
     });
     return result.approved;
   }
@@ -366,6 +429,12 @@ export class ApprovalGateSkill {
           file_changes: fileChanges,
           diff_summary: diffSummary,
         },
+      },
+      rollback: {
+        title: `Rollback push to ${branch}`,
+        description: `Revert the pushed change through a follow-up commit instead of rewriting shared history.`,
+        command: 'git revert HEAD && git push origin HEAD',
+        metadata: { repository, branch, file_changes: fileChanges },
       },
     });
     return result.approved;

--- a/openclaw-skills/src/types/protocol.ts
+++ b/openclaw-skills/src/types/protocol.ts
@@ -175,6 +175,86 @@ export interface ApprovalResponse {
   responded_at: string; // ISO8601
 }
 
+// ─── Agent Governance ────────────────────────────────────────────────────────
+
+/** Lifecycle state for a long-running agent plan item. */
+export type AgentPlanStepStatus = 'pending' | 'running' | 'done' | 'blocked' | 'skipped';
+
+/** A durable plan item tracked independently from transient prompt context. */
+export interface AgentPlanStep {
+  id: string;
+  agent_id: string;
+  title: string;
+  details: string;
+  status: AgentPlanStepStatus;
+  owner: string | null;
+  evidence: ResourceLink[];
+  created_at: string; // ISO8601
+  updated_at: string; // ISO8601
+}
+
+/** Snapshot of an external condition the agent relied on. */
+export interface EnvironmentObservation {
+  id: string;
+  agent_id: string;
+  source: string;
+  summary: string;
+  observed_at: string; // ISO8601
+  metadata: Record<string, unknown>;
+}
+
+/** A verified recovery target for a risky agent action. */
+export interface RollbackPoint {
+  id: string;
+  agent_id: string;
+  action_type: ActionType;
+  title: string;
+  description: string;
+  command: string;
+  created_at: string; // ISO8601
+  metadata: Record<string, unknown>;
+}
+
+/** Append-only event categories for audit and replay. */
+export type GovernanceEventType =
+  | 'agent_objective_updated'
+  | 'agent_plan_step_upserted'
+  | 'environment_observed'
+  | 'rollback_point_added'
+  | 'approval_requested'
+  | 'approval_decided'
+  | 'approval_expired'
+  | 'task_state_changed'
+  | 'incident_state_changed';
+
+/** Append-only audit event for long-running agent governance. */
+export interface GovernanceEvent {
+  id: string;
+  agent_id: string;
+  type: GovernanceEventType;
+  title: string;
+  summary: string;
+  created_at: string; // ISO8601
+  actor: 'agent' | 'human' | 'gateway' | 'policy';
+  risk_level?: RiskLevel;
+  approval_id?: string;
+  task_id?: string;
+  incident_id?: string;
+  rollback_point_id?: string;
+  metadata: Record<string, unknown>;
+}
+
+/** Current governable state for a long-running agent. */
+export interface AgentGovernanceState {
+  agent_id: string;
+  current_objective: string | null;
+  objective_updated_at: string | null;
+  plan: AgentPlanStep[];
+  environment: EnvironmentObservation[];
+  rollback_points: RollbackPoint[];
+  events: GovernanceEvent[];
+}
+
 // ─── Chat ─────────────────────────────────────────────────────────────────────
 
 /** A chat message between user and agent. */
@@ -249,6 +329,7 @@ export type ServerEventType =
   | 'incident_new'
   | 'incident_update'
   | 'approval_request'
+  | 'governance_event'
   | 'chat_response'
   | 'bridge_session_new'
   | 'bridge_session_update'

--- a/openclaw-skills/tests/approval-gate-policy.test.ts
+++ b/openclaw-skills/tests/approval-gate-policy.test.ts
@@ -85,4 +85,49 @@ describe('ApprovalGateSkill policy presets', () => {
     expect(result.approved).toBe(true);
     expect(gate.getDecisionLog()[0]?.autoApproved).toBe(false);
   });
+
+  test('approved dangerous action records rollback point and audit events', async () => {
+    const state = new StateManager();
+    await state.upsertAgent(makeAgent());
+    const gate = new ApprovalGateSkill(state, {
+      ...DEFAULT_CONFIG,
+      approvalPolicyPreset: 'manual',
+    });
+
+    const promise = gate.requestApproval({
+      agentId: 'agent-policy',
+      agentName: 'Policy Agent',
+      actionType: 'deploy',
+      title: 'Deploy API',
+      description: 'Deploy API to production',
+      command: 'kubectl set image deployment/api api=api:v2 -n production',
+      timeoutMs: 10_000,
+      context: {
+        service: 'api',
+        environment: 'production',
+        repository: 'IgorGanapolsky/openclaw-console',
+        riskLevel: 'critical',
+      },
+      rollback: {
+        title: 'Rollback API deployment',
+        description: 'Undo the latest API rollout',
+        command: 'kubectl rollout undo deployment/api -n production',
+      },
+    });
+
+    const pending = state.listPendingApprovals();
+    state.respondToApproval({
+      approval_id: pending[0]!.id,
+      decision: 'approved',
+      biometric_verified: true,
+      responded_at: new Date().toISOString(),
+    });
+
+    await promise;
+    const governance = state.getAgentGovernance('agent-policy');
+    expect(governance.rollback_points[0]?.command).toBe('kubectl rollout undo deployment/api -n production');
+    expect(governance.events.map((event) => event.type)).toContain('approval_requested');
+    expect(governance.events.map((event) => event.type)).toContain('approval_decided');
+    expect(governance.events.map((event) => event.type)).toContain('rollback_point_added');
+  });
 });

--- a/openclaw-skills/tests/protocol.test.ts
+++ b/openclaw-skills/tests/protocol.test.ts
@@ -5,6 +5,9 @@
  * and end-to-end flows for approvals, incidents, and tasks.
  */
 
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { jest } from '@jest/globals';
 import { StateManager } from '../src/gateway/state';
 import type {
@@ -247,6 +250,82 @@ describe('Approval flow (request → response)', () => {
       responded_at: new Date().toISOString(),
     });
     expect(result).toBeNull();
+  });
+});
+
+// ── Governance state ────────────────────────────────────────────────────────
+
+describe('Agent governance state', () => {
+  test('tracks objective, plan, environment observations, rollback points, and events', async () => {
+    const state = new StateManager();
+    await state.upsertAgent(makeAgent({ id: 'agent-governance' }));
+
+    await state.updateAgentObjective('agent-governance', 'Investigate failing production deploy', 'human');
+    const step = await state.upsertAgentPlanStep({
+      agent_id: 'agent-governance',
+      title: 'Check rollout status',
+      status: 'running',
+      owner: 'Deploy Manager',
+    });
+    await state.recordEnvironmentObservation({
+      agent_id: 'agent-governance',
+      source: 'kubernetes',
+      summary: 'deployment/api has one unavailable replica',
+      metadata: { unavailable_replicas: 1 },
+    });
+    await state.addRollbackPoint({
+      agent_id: 'agent-governance',
+      action_type: 'deploy',
+      title: 'Rollback API deployment',
+      description: 'Undo the latest rollout',
+      command: 'kubectl rollout undo deployment/api -n production',
+    });
+
+    const governance = state.getAgentGovernance('agent-governance');
+    expect(governance.current_objective).toBe('Investigate failing production deploy');
+    expect(governance.plan[0]?.id).toBe(step.id);
+    expect(governance.environment[0]?.metadata['unavailable_replicas']).toBe(1);
+    expect(governance.rollback_points[0]?.action_type).toBe('deploy');
+    expect(governance.events.map((event) => event.type)).toEqual([
+      'agent_objective_updated',
+      'agent_plan_step_upserted',
+      'environment_observed',
+      'rollback_point_added',
+    ]);
+  });
+
+  test('persists and replays governance events from JSONL', async () => {
+    const logPath = path.join(os.tmpdir(), `openclaw-governance-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`);
+    const first = new StateManager({ governanceEventLogPath: logPath });
+    await first.updateAgentObjective('agent-replay', 'Recover production API', 'gateway');
+    const step = await first.upsertAgentPlanStep({
+      agent_id: 'agent-replay',
+      title: 'Confirm rollback command',
+      status: 'done',
+    });
+    await first.recordEnvironmentObservation({
+      agent_id: 'agent-replay',
+      source: 'healthcheck',
+      summary: 'api healthcheck failing',
+    });
+    await first.addRollbackPoint({
+      agent_id: 'agent-replay',
+      action_type: 'deploy',
+      title: 'Rollback API',
+      description: 'Undo latest deploy',
+      command: 'kubectl rollout undo deployment/api -n production',
+    });
+
+    const second = new StateManager({ governanceEventLogPath: logPath });
+    const events = second.listGovernanceEvents('agent-replay');
+    const governance = second.getAgentGovernance('agent-replay');
+    expect(events).toHaveLength(4);
+    expect(governance.current_objective).toBe('Recover production API');
+    expect(governance.plan[0]?.id).toBe(step.id);
+    expect(governance.environment[0]?.summary).toBe('api healthcheck failing');
+    expect(governance.rollback_points[0]?.command).toBe('kubectl rollout undo deployment/api -n production');
+
+    fs.rmSync(logPath, { force: true });
   });
 });
 

--- a/openclaw-skills/tests/runtime-config.test.ts
+++ b/openclaw-skills/tests/runtime-config.test.ts
@@ -27,8 +27,11 @@ function tempConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   };
 }
 
-async function start(config: GatewayConfig): Promise<{ server: GatewayServer; baseUrl: string; token: string }> {
-  const server = createGatewayServer(config, new StateManager());
+async function start(
+  config: GatewayConfig,
+  state: StateManager = new StateManager(),
+): Promise<{ server: GatewayServer; baseUrl: string; token: string; state: StateManager }> {
+  const server = createGatewayServer(config, state);
   servers.push(server);
   await server.start();
   const address = server.httpServer.address();
@@ -43,6 +46,7 @@ async function start(config: GatewayConfig): Promise<{ server: GatewayServer; ba
     server,
     baseUrl: `http://127.0.0.1:${address.port}`,
     token,
+    state,
   };
 }
 
@@ -88,6 +92,35 @@ describe('runtime config API', () => {
 
     expect(response.status).toBe(400);
     expect(config.approvalPolicyPreset).toBe(DEFAULT_CONFIG.approvalPolicyPreset);
+
+    fs.rmSync(config.tokenStorePath, { force: true });
+  });
+
+  test('returns authenticated governance state for an agent', async () => {
+    const config = tempConfig();
+    const state = new StateManager();
+    await state.upsertAgent({
+      id: 'agent-http-governance',
+      name: 'HTTP Governance Agent',
+      description: 'Test agent',
+      status: 'online',
+      workspace: 'test',
+      tags: ['test'],
+      last_active: new Date().toISOString(),
+      active_tasks: 0,
+      pending_approvals: 0,
+    });
+    await state.updateAgentObjective('agent-http-governance', 'Verify governance endpoint', 'gateway');
+    const { baseUrl, token } = await start(config, state);
+
+    const response = await fetch(`${baseUrl}/api/agents/agent-http-governance/governance`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as Record<string, unknown>;
+    expect(body['current_objective']).toBe('Verify governance endpoint');
+    expect(Array.isArray(body['events'])).toBe(true);
 
     fs.rmSync(config.tokenStorePath, { force: true });
   });


### PR DESCRIPTION
## Summary
- add durable agent governance state for objectives, plan steps, environment observations, rollback points, and audit events
- expose authenticated governance REST routes and WebSocket governance events
- record approval decisions and rollback metadata, plus update iOS/Android protocol models

## Cleanup performed
- rebased the PR onto current develop
- removed stale stacked Multica/structured-prompt commits from the PR diff

## Local verification
- npm run lint
- npm run build
- npm test -- --runInBand (10 suites, 101 tests)
- ./gradlew compileDebugKotlin
- ./gradlew testDebugUnitTest
- git diff --check

## Pending verification
- GitHub PR checks after branch rewrite
- iOS simulator build is still resolving RevenueCat packages locally and in CI; result not yet verified