### PR TITLE
fix: harden internal TestFlight distribution observability

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -63,6 +63,7 @@ jobs:
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true'
     runs-on: macos-15
+    timeout-minutes: 45
     environment: production
     steps:
       - uses: actions/checkout@v5
@@ -147,7 +148,34 @@ jobs:
         run: bundle exec fastlane setup
         working-directory: ios/OpenClawConsole
 
-      - name: Build and upload to TestFlight
+      - name: Archive IPA for TestFlight
+        timeout-minutes: 30
+        env:
+          CI: "true"
+          FASTLANE_SKIP_UPDATE_CHECK: "true"
+          FASTLANE_DISABLE_COLORS: "true"
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: "6"
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          APPSTORE_KEY_PATH: ${{ env.APPSTORE_KEY_PATH }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || secrets.TESTFLIGHT_GROUPS || 'Internal Testers' }}
+          TESTFLIGHT_DISTRIBUTE_EXTERNAL: "false"
+          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "false"
+          TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING: "true"
+          TESTFLIGHT_ARCHIVE_ONLY: "true"
+        run: |
+          set -Eeuo pipefail
+          bundle exec fastlane beta --verbose 2>&1 | tee fastlane-archive.log
+        working-directory: ios/OpenClawConsole
+
+      - name: Upload archived IPA to TestFlight
+        timeout-minutes: 15
         env:
           CI: "true"
           FASTLANE_SKIP_UPDATE_CHECK: "true"
@@ -164,15 +192,42 @@ jobs:
           TESTFLIGHT_DISTRIBUTE_EXTERNAL: "false"
           TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "false"
           TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING: "true"
-        run: bundle exec fastlane beta
+          TESTFLIGHT_UPLOAD_ONLY: "true"
+        run: |
+          set -Eeuo pipefail
+          bundle exec fastlane beta --verbose 2>&1 | tee fastlane-upload.log
         working-directory: ios/OpenClawConsole
 
-      - name: Upload IPA artifact
+      - name: Collect iOS distribution logs
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p ios/OpenClawConsole/build-logs/gym
+          if [ -d "$HOME/Library/Logs/gym" ]; then
+            cp -R "$HOME/Library/Logs/gym/." ios/OpenClawConsole/build-logs/gym/
+          fi
+
+      - name: Show iOS distribution log tail
+        if: failure()
+        run: |
+          set -euo pipefail
+          for log in ios/OpenClawConsole/fastlane-archive.log ios/OpenClawConsole/fastlane-upload.log; do
+            if [ -f "$log" ]; then
+              echo "===== tail $log ====="
+              tail -n 200 "$log"
+            fi
+          done
+
+      - name: Upload iOS distribution artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ios-ipa-internal
-          path: ios/OpenClawConsole/OpenClawConsole.ipa
+          name: ios-distribution-internal
+          path: |
+            ios/OpenClawConsole/OpenClawConsole.ipa
+            ios/OpenClawConsole/fastlane-archive.log
+            ios/OpenClawConsole/fastlane-upload.log
+            ios/OpenClawConsole/build-logs
           if-no-files-found: warn
 
   android-firebase-internal:

--- a/ios/OpenClawConsole/fastlane/Fastfile
+++ b/ios/OpenClawConsole/fastlane/Fastfile
@@ -1,3 +1,5 @@
+require "fileutils"
+
 default_platform(:ios)
 
 APP_IDENTIFIER = "com.openclaw.console"
@@ -82,6 +84,14 @@ def resolve_next_build_number(api_key:, marketing_version:)
   next_build_number
 end
 
+def configured_ipa_path
+  File.expand_path("OpenClawConsole.ipa", Dir.pwd)
+end
+
+def configured_buildlog_path
+  File.expand_path("build-logs", Dir.pwd)
+end
+
 platform :ios do
   desc "Push a new beta build to TestFlight"
   lane :beta do
@@ -89,117 +99,131 @@ platform :ios do
 
     # Use App Store Connect API key if available
     api_key = app_store_api_key_from_env
+    archive_only = truthy_env?("TESTFLIGHT_ARCHIVE_ONLY", default: false)
+    upload_only = truthy_env?("TESTFLIGHT_UPLOAD_ONLY", default: false)
 
-    marketing_version = get_version_number(
-      xcodeproj: "OpenClawConsole.xcodeproj",
-      target: "OpenClawConsole"
-    )
-    next_build_number = resolve_next_build_number(
-      api_key: api_key,
-      marketing_version: marketing_version
-    )
-
-    UI.message("Using build number #{next_build_number} for version #{marketing_version}")
-
-    # Force update build number in ALL possible locations to ensure it sticks
-
-    # Method 1: Fastlane increment_build_number
-    increment_build_number(
-      xcodeproj: "OpenClawConsole.xcodeproj",
-      build_number: next_build_number
-    )
-
-    # Method 2: Direct agvtool update (low level)
-    sh("cd .. && agvtool new-version -all #{next_build_number}")
-
-    # Method 3: Update CFBundleVersion in Info.plist directly
-    sh("cd .. && /usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{next_build_number}' OpenClawConsole/Info.plist")
-
-    # Verify the build number was actually set
-    updated_build_number = get_build_number(xcodeproj: "OpenClawConsole.xcodeproj").to_i
-    UI.message("Verified build number in project: #{updated_build_number}")
-
-    # Also verify via agvtool
-    agvtool_version = sh("cd .. && agvtool what-version -terse", return_stdout: true).strip.to_i
-    UI.message("Verified build number via agvtool: #{agvtool_version}")
-
-    if updated_build_number != next_build_number || agvtool_version != next_build_number
-      UI.user_error!("Build number update failed! Expected #{next_build_number}, fastlane: #{updated_build_number}, agvtool: #{agvtool_version}")
+    if archive_only && upload_only
+      UI.user_error!("TESTFLIGHT_ARCHIVE_ONLY and TESTFLIGHT_UPLOAD_ONLY cannot both be true")
     end
 
-    if ENV["CI"] == "true" && ENV["MATCH_GIT_URL"] && api_key
-      UI.message("CI detected - using match-managed App Store signing")
-
-      create_keychain(
-        name: "fastlane_tmp_keychain",
-        password: "temp_password",
-        default_keychain: false,
-        unlock: true,
-        timeout: 3600,
-        add_to_search_list: true
+    unless upload_only
+      marketing_version = get_version_number(
+        xcodeproj: "OpenClawConsole.xcodeproj",
+        target: "OpenClawConsole"
       )
-
-      match(
-        type: "appstore",
-        app_identifier: ["com.openclaw.console"],
-        readonly: true,
+      next_build_number = resolve_next_build_number(
         api_key: api_key,
-        keychain_name: "fastlane_tmp_keychain",
-        keychain_password: "temp_password"
+        marketing_version: marketing_version
       )
 
-      app_profile = ENV["sigh_com.openclaw.console_appstore_profile-name"] || "match AppStore com.openclaw.console"
+      UI.message("Using build number #{next_build_number} for version #{marketing_version}")
 
-      update_code_signing_settings(
-        path: "OpenClawConsole.xcodeproj",
-        use_automatic_signing: false,
-        targets: ["OpenClawConsole"],
-        code_sign_identity: "Apple Distribution",
-        profile_name: app_profile,
-        team_id: ENV["APPLE_TEAM_ID"]
+      increment_build_number(
+        xcodeproj: "OpenClawConsole.xcodeproj",
+        build_number: next_build_number
       )
+      sh("cd .. && agvtool new-version -all #{next_build_number}")
+      sh("cd .. && /usr/libexec/PlistBuddy -c 'Set :CFBundleVersion #{next_build_number}' OpenClawConsole/Info.plist")
 
-      build_app(
-        scheme: "OpenClawConsole",
-        export_method: "app-store",
-        export_options: {
-          signingStyle: "manual",
-          provisioningProfiles: {
-            "com.openclaw.console" => app_profile
-          }
-        }
-      )
-    else
-      UI.message("Using automatic signing path for local or non-match environments")
+      updated_build_number = get_build_number(xcodeproj: "OpenClawConsole.xcodeproj").to_i
+      UI.message("Verified build number in project: #{updated_build_number}")
 
-      if ENV["APPLE_TEAM_ID"] && !ENV["APPLE_TEAM_ID"].empty?
+      agvtool_version = sh("cd .. && agvtool what-version -terse", return_stdout: true).strip.to_i
+      UI.message("Verified build number via agvtool: #{agvtool_version}")
+
+      if updated_build_number != next_build_number || agvtool_version != next_build_number
+        UI.user_error!("Build number update failed! Expected #{next_build_number}, fastlane: #{updated_build_number}, agvtool: #{agvtool_version}")
+      end
+
+      FileUtils.mkdir_p(configured_buildlog_path)
+
+      if ENV["CI"] == "true" && ENV["MATCH_GIT_URL"] && api_key
+        UI.message("CI detected - using match-managed App Store signing")
+
+        create_keychain(
+          name: "fastlane_tmp_keychain",
+          password: "temp_password",
+          default_keychain: false,
+          unlock: true,
+          timeout: 3600,
+          add_to_search_list: true
+        )
+
+        match(
+          type: "appstore",
+          app_identifier: ["com.openclaw.console"],
+          readonly: true,
+          api_key: api_key,
+          keychain_name: "fastlane_tmp_keychain",
+          keychain_password: "temp_password"
+        )
+
+        app_profile = ENV["sigh_com.openclaw.console_appstore_profile-name"] || "match AppStore com.openclaw.console"
+
         update_code_signing_settings(
           path: "OpenClawConsole.xcodeproj",
-          use_automatic_signing: true,
+          use_automatic_signing: false,
           targets: ["OpenClawConsole"],
+          code_sign_identity: "Apple Distribution",
+          profile_name: app_profile,
           team_id: ENV["APPLE_TEAM_ID"]
         )
-      end
 
-      build_args = [
-        "-allowProvisioningUpdates",
-        "-allowProvisioningDeviceRegistration"
-      ]
+        build_app(
+          scheme: "OpenClawConsole",
+          export_method: "app-store",
+          output_directory: ".",
+          output_name: "OpenClawConsole.ipa",
+          buildlog_path: configured_buildlog_path,
+          build_timing_summary: true,
+          export_options: {
+            signingStyle: "manual",
+            provisioningProfiles: {
+              "com.openclaw.console" => app_profile
+            }
+          }
+        )
+      else
+        UI.message("Using automatic signing path for local or non-match environments")
 
-      if api_key && ENV["APPSTORE_KEY_PATH"]
-        build_args += [
-          "-authenticationKeyID", ENV['APPSTORE_KEY_ID'],
-          "-authenticationKeyIssuerID", ENV['APPSTORE_ISSUER_ID'],
-          "-authenticationKeyPath", ENV['APPSTORE_KEY_PATH']
+        if ENV["APPLE_TEAM_ID"] && !ENV["APPLE_TEAM_ID"].empty?
+          update_code_signing_settings(
+            path: "OpenClawConsole.xcodeproj",
+            use_automatic_signing: true,
+            targets: ["OpenClawConsole"],
+            team_id: ENV["APPLE_TEAM_ID"]
+          )
+        end
+
+        build_args = [
+          "-allowProvisioningUpdates",
+          "-allowProvisioningDeviceRegistration"
         ]
-      end
 
-      build_app(
-        scheme: "OpenClawConsole",
-        export_method: "app-store",
-        xcargs: build_args.join(" "),
-        skip_profile_detection: true
-      )
+        if api_key && ENV["APPSTORE_KEY_PATH"]
+          build_args += [
+            "-authenticationKeyID", ENV['APPSTORE_KEY_ID'],
+            "-authenticationKeyIssuerID", ENV['APPSTORE_ISSUER_ID'],
+            "-authenticationKeyPath", ENV['APPSTORE_KEY_PATH']
+          ]
+        end
+
+        build_app(
+          scheme: "OpenClawConsole",
+          export_method: "app-store",
+          output_directory: ".",
+          output_name: "OpenClawConsole.ipa",
+          buildlog_path: configured_buildlog_path,
+          build_timing_summary: true,
+          xcargs: build_args.join(" "),
+          skip_profile_detection: true
+        )
+      end
+    end
+
+    if archive_only
+      UI.message("TESTFLIGHT_ARCHIVE_ONLY=true; skipping upload_to_testflight")
+      next
     end
 
     if ENV["TESTFLIGHT_SYNC_TESTERS"] == "true"
@@ -211,6 +235,7 @@ platform :ios do
     upload_options = {
       skip_waiting_for_build_processing: truthy_env?("TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING", default: true),
       api_key: api_key,
+      ipa: configured_ipa_path,
       beta_app_description: ENV["TESTFLIGHT_BETA_DESCRIPTION"] || "OpenClaw Console beta build for external testing.",
       beta_app_feedback_email: ENV["TESTFLIGHT_FEEDBACK_EMAIL"] || "igor.ganapolsky@icloud.com",
       changelog: "Latest OpenClaw Console beta build"


### PR DESCRIPTION
## What changed
- split iOS internal distribution into separate archive and upload phases
- add timeouts to prevent indefinite TestFlight hangs
- persist Fastlane and gym logs as artifacts on every run
- make the Fastlane beta lane support archive-only and upload-only execution with a deterministic IPA path

## Why
The current develop workflow can sit in a single opaque `Build and upload to TestFlight` step for an extended period with no terminal status and no readable logs. This change makes the failing phase explicit and artifacts the evidence needed to debug it.

## Local verification
- `ruby -c ios/OpenClawConsole/fastlane/Fastfile`
- YAML parse of `.github/workflows/internal-distribution.yml`
- `git diff --check`
