### PR TITLE
fix: harden internal distribution timeout and directives

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -149,7 +149,7 @@ jobs:
         working-directory: ios/OpenClawConsole
 
       - name: Archive IPA for TestFlight
-        timeout-minutes: 30
+        timeout-minutes: 60
         env:
           CI: "true"
           FASTLANE_SKIP_UPDATE_CHECK: "true"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,14 @@ Mobile apps are thin clients. All intelligence lives in OpenClaw skills on the u
 1. `develop` → `release/vX.Y.Z` → TestFlight + Google Play → tag on `main` → merge back to `develop`
 2. Hotfix: `main` → `hotfix/vX.Y.Z` → stores → tag on `main` → merge to `develop`
 
+## Session Directive: PR Management & System Hygiene
+
+1. Inspect all open PRs and report merge readiness with evidence.
+2. Identify orphan branches and classify each one as active, merge candidate, stale, or delete.
+3. Merge only PRs that are verified green and review-ready.
+4. Clean up stale branches, redundant worktrees, and obvious repo hygiene issues.
+5. Verify CI on `develop` and `main` before claiming readiness.
+
 ## Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,4 +113,4 @@ Every release MUST include complete store listing metadata before publishing:
 - **No Manual Handoffs**: Perform every possible step autonomously.
 - **Honesty**: Report failures immediately. Lying is not allowed.
 - **Say "I believe this is done, verifying now..."** instead of "Done!"
-
+- **No Repo Secrets in Docs**: Never write tokens, passwords, or private keys into tracked documentation.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,44 +1,47 @@
-# GEMINI.md — Foundational Mandates
+# GEMINI.md — OpenClaw Work Console
 
-## Core Directive: Fully Autonomous CTO
+## Core Directive: Autonomous CTO
 
-I am the **fully autonomous CTO** of this project. The user is the **CEO**.
-- I have full agentic authority to act autonomously.
-- I do not ask for permission for technical executions.
-- I am responsible for end-to-end delivery, including publishing, maintenance, and security.
-- I must never ask the CEO to execute manual commands; I execute them myself.
+I am the **autonomous CTO** of this project. The user is the **CEO**.
+- I act autonomously on technical execution.
+- I own end-to-end delivery, maintenance, and system hygiene.
+- I do not hand off runnable work to the CEO when I can execute it myself.
 
-## Configuration Model Directive
+## Evidence Mandate
 
-- **MODEL PROJECT**: Use the same values, setup, architectural patterns, and automation workflows as the `/Users/ganapolsky_i/workspace/git/igor/Random-Timer` project.
-- Always refer to `Random-Timer` when in doubt about configuration, secrets naming, or CI/CD setup.
+1. Never claim a task is done without direct verification.
+2. Never present planned work as completed work.
+3. Every status claim must be backed by concrete evidence: command output, API read-back, SHA, or CI run state.
+4. If a fact is unverified, label it as unverified.
 
-## App Store & Apple Configuration
+## Secrets & Environment Protocol
 
-Credentials must match the patterns established in `Random-Timer`.
-
-### App Store Configuration
-- **App Bundle ID**: `com.openclaw.console`
-- **Distribution Certificate**: Use Match with the `certificates` repo and `Rockland26&*` password.
-
-### Credential Sources
-- **Local**: `.env` (FASTLANE_USER, FASTLANE_PASSWORD, FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD)
-- **CI**: `gh secret list` (APPSTORE_ISSUER_ID, APPSTORE_KEY_ID, APPSTORE_PRIVATE_KEY, APPLE_TEAM_ID, FASTLANE_USER, FASTLANE_PASSWORD, MATCH_GIT_URL, MATCH_PASSWORD)
-
-## Operational Standards
-- **Evidence-Based**: Every claim must be backed by hard proof (logs, API read-backs).
-- **GSD (Get-Shit-Done)**: Prioritize speed and delivery. Use Ralph Mode and parallel agents for complex tasks.
-- **Act, Don't Instruct**: Execute autonomously. Never tell the CEO to do manual steps.
-- **Verification**: Never claim "done" without running verification commands and showing output.
+1. Check local `.env` key names first without exposing values.
+2. Check GitHub Actions secret names with `gh secret list`.
+3. Do not store secrets, PATs, or passwords in repo docs.
+4. If credentials are updated, verify access with a real authenticated read-back.
 
 ## Git Flow & Worktree Protocol
-- Follow the same Git Flow and Worktree rules as defined in `Random-Timer/docs/GEMINI.md`.
 
-## Anti-Lying Mandate (Critical)
+- All code changes happen in a git worktree.
+- Never commit directly to `develop`, `main`, or the user's active branch.
+- Push worktree branches and use PRs for review and merge.
+- Branch names:
+  - `feat/{description}`
+  - `fix/{description}`
+  - `release/vX.Y.Z`
+  - `hotfix/vX.Y.Z`
 
-1. Never fabricate facts, outputs, permissions, CI status, merge status, invites, or deployment state.
-2. Never report "done" without direct verification evidence.
-3. Never present planned work as completed work.
-4. If state is unknown or unverified, say so explicitly.
-5. If a previous claim was wrong, correct it immediately with concrete proof.
-6. Claims without evidence are invalid and must be treated as unresolved.
+## Session Directive: PR Management & System Hygiene
+
+1. Inspect all open PRs and report merge readiness with evidence.
+2. Identify orphan branches and classify them as active, merge candidate, stale, or delete.
+3. Merge only PRs that are verified green and review-ready.
+4. Clean up stale branches, redundant worktrees, and obvious repo hygiene issues.
+5. Verify CI on `develop` and `main` before claiming readiness.
+
+## Key Identifiers
+
+- iOS bundle ID: `com.openclaw.console`
+- Android package: `com.openclaw.console`
+- Gateway default port: `18789`

--- a/ios/OpenClawConsole/fastlane/Fastfile
+++ b/ios/OpenClawConsole/fastlane/Fastfile
@@ -95,7 +95,7 @@ end
 platform :ios do
   desc "Push a new beta build to TestFlight"
   lane :beta do
-    setup_ci if ENV["CI"] == "true"
+    setup_ci(timeout: 0) if ENV["CI"] == "true"
 
     # Use App Store Connect API key if available
     api_key = app_store_api_key_from_env
@@ -264,7 +264,7 @@ platform :ios do
 
   desc "Setup certificates and profiles via match"
   lane :setup do
-    setup_ci if ENV["CI"] == "true"
+    setup_ci(timeout: 0) if ENV["CI"] == "true"
 
     if ENV["MATCH_GIT_URL"] && ENV["MATCH_PASSWORD"]
       api_key = app_store_api_key_from_env

--- a/openclaw-skills/src/billing/revenuecat.ts
+++ b/openclaw-skills/src/billing/revenuecat.ts
@@ -243,8 +243,6 @@ export function hasProEntitlement(customerInfo: CustomerInfo): boolean {
  * Check premium feature access
  */
 export async function checkPremiumAccess(userId: string, feature: string): Promise<boolean> {
-  const status = await getSubscriptionStatus(userId);
-
   // Free tier features (always allowed)
   const freeTierFeatures = [
     'basic_approvals',
@@ -266,6 +264,7 @@ export async function checkPremiumAccess(userId: string, feature: string): Promi
   ];
 
   if (proFeatures.includes(feature)) {
+    const status = await getSubscriptionStatus(userId);
     return status.isPro && status.hasActiveSubscription;
   }
 

--- a/openclaw-skills/tests/billing/revenuecat.test.ts
+++ b/openclaw-skills/tests/billing/revenuecat.test.ts
@@ -93,18 +93,36 @@ describe('RevenueCat Billing', () => {
 
   describe('checkPremiumAccess', () => {
     it('should allow free tier features without subscription', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn(() => Promise.reject(new Error('fetch should not be called'))) as any;
+
       const hasAccess = await checkPremiumAccess('test-user', 'basic_approvals');
       expect(hasAccess).toBe(true);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      global.fetch = originalFetch;
     });
 
     it('should allow free tier features: agent monitoring', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn(() => Promise.reject(new Error('fetch should not be called'))) as any;
+
       const hasAccess = await checkPremiumAccess('test-user', 'agent_monitoring');
       expect(hasAccess).toBe(true);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      global.fetch = originalFetch;
     });
 
     it('should allow free tier features: simple notifications', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn(() => Promise.reject(new Error('fetch should not be called'))) as any;
+
       const hasAccess = await checkPremiumAccess('test-user', 'simple_notifications');
       expect(hasAccess).toBe(true);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      global.fetch = originalFetch;
     });
 
     it('should deny pro features without subscription', async () => {
@@ -119,8 +137,14 @@ describe('RevenueCat Billing', () => {
     });
 
     it('should allow unknown features (default to free)', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn(() => Promise.reject(new Error('fetch should not be called'))) as any;
+
       const hasAccess = await checkPremiumAccess('test-user', 'unknown_feature');
       expect(hasAccess).toBe(true);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      global.fetch = originalFetch;
     });
   });
 


### PR DESCRIPTION
Summary:
- increase the TestFlight archive step timeout from 30 to 60 minutes
- disable fastlane CI keychain timeout in the beta and setup lanes
- align CLAUDE.md, GEMINI.md, and AGENTS.md with PR-management and no-secrets rules

Verification:
- ruby -c ios/OpenClawConsole/fastlane/Fastfile
- python3 YAML parse of .github/workflows/internal-distribution.yml