### PR TITLE
fix: enforce release contract guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,23 @@ jobs:
       - name: Verify canonical icon sync
         run: python3 scripts/sync_app_icons.py --check
 
+  release-contract:
+    name: Release Contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Pillow
+        run: python3 -m pip install pillow
+
+      - name: Validate release contract
+        run: python3 scripts/validate_release_contract.py --platform both
+
   lint-kotlin:
     name: Architecture Lint (Kotlin)
     runs-on: ubuntu-latest

--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -70,6 +70,14 @@ jobs:
         with:
           ref: ${{ needs.gate.outputs.ref }}
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Pillow
+        run: python3 -m pip install pillow
+
       - name: Fail fast on required iOS distribution secrets
         env:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
@@ -90,11 +98,6 @@ jobs:
 
       - name: Preflight release checks (iOS)
         run: bash scripts/preflight-release.sh --platform ios --layer 1
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -240,6 +243,14 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.gate.outputs.ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Pillow
+        run: python3 -m pip install pillow
 
       - name: Fail fast on Android distribution auth inputs
         env:

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -42,6 +42,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install Pillow
+        run: python3 -m pip install pillow
+
       - name: Fail fast on required iOS release secrets
         env:
           APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
@@ -62,11 +70,6 @@ jobs:
 
       - name: Preflight release checks (iOS)
         run: bash scripts/preflight-release.sh --platform ios --layer 1
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -161,6 +164,17 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install Pillow
+        run: python3 -m pip install pillow
+
+      - name: Preflight release checks (Android)
+        run: bash scripts/preflight-release.sh --platform android --layer 1
 
       - name: Setup Java
         uses: actions/setup-java@v5

--- a/.github/workflows/store-listing-parity.yml
+++ b/.github/workflows/store-listing-parity.yml
@@ -21,58 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify Android metadata
-        run: |
-          ERRORS=0
-          BASE="android/fastlane/metadata/android/en-US"
-          for file in title.txt short_description.txt full_description.txt; do
-            if [ ! -f "$BASE/$file" ]; then
-              echo "::error::Missing Android metadata: $BASE/$file"
-              ERRORS=$((ERRORS + 1))
-            elif [ ! -s "$BASE/$file" ]; then
-              echo "::error::Empty Android metadata: $BASE/$file"
-              ERRORS=$((ERRORS + 1))
-            fi
-          done
-          if [ ! -d "$BASE/changelogs" ]; then
-            echo "::warning::No changelogs directory: $BASE/changelogs/"
-          fi
-          if [ "$ERRORS" -gt 0 ]; then
-            exit 1
-          fi
-          echo "Android store metadata: OK"
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
 
-      - name: Verify iOS metadata
-        run: |
-          ERRORS=0
-          BASE="ios/OpenClawConsole/fastlane/metadata/en-US"
-          for file in name.txt subtitle.txt description.txt keywords.txt release_notes.txt; do
-            if [ ! -f "$BASE/$file" ]; then
-              echo "::error::Missing iOS metadata: $BASE/$file"
-              ERRORS=$((ERRORS + 1))
-            elif [ ! -s "$BASE/$file" ]; then
-              echo "::error::Empty iOS metadata: $BASE/$file"
-              ERRORS=$((ERRORS + 1))
-            fi
-          done
-          if [ "$ERRORS" -gt 0 ]; then
-            exit 1
-          fi
-          echo "iOS store metadata: OK"
+      - name: Install Pillow
+        run: python3 -m pip install pillow
 
-      - name: Verify privacy policy exists
-        run: |
-          if [ ! -f "PRIVACY_POLICY.md" ]; then
-            echo "::error::PRIVACY_POLICY.md is missing"
-            exit 1
-          fi
-          echo "Privacy policy: OK"
-
-      - name: Cross-platform parity check
-        run: |
-          ANDROID_TITLE=$(cat android/fastlane/metadata/android/en-US/title.txt 2>/dev/null || echo "")
-          IOS_NAME=$(cat ios/OpenClawConsole/fastlane/metadata/en-US/name.txt 2>/dev/null || echo "")
-          if [ -n "$ANDROID_TITLE" ] && [ -n "$IOS_NAME" ] && [ "$ANDROID_TITLE" != "$IOS_NAME" ]; then
-            echo "::warning::App name mismatch — Android: '$ANDROID_TITLE' vs iOS: '$IOS_NAME'"
-          fi
-          echo "Parity check complete"
+      - name: Validate release contract
+        run: python3 scripts/validate_release_contract.py --platform both

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: verify verify-android verify-ios verify-skills
+.PHONY: verify verify-android verify-ios verify-skills verify-release-contract
 .PHONY: run-android-device run-android-emulator run-ios-device run-ios-sim fix-ios-device
 .PHONY: maestro-android maestro-ios
 .PHONY: clean clean-android clean-ios clean-skills clean-all
@@ -12,7 +12,11 @@ ANDROID_PACKAGE := com.openclaw.console
 IOS_SCHEME := OpenClawConsole
 
 # Verify (unit tests + builds)
-verify: verify-android verify-ios verify-skills
+verify: verify-release-contract verify-android verify-ios verify-skills
+
+verify-release-contract:
+	@echo "==> Release contract: icons + metadata + release inputs"
+	@python3 scripts/validate_release_contract.py --platform both
 
 verify-android:
 	@echo "==> Android: unit tests + debug build"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         targetSdk = 35
         val ciVersionCode = providers.gradleProperty("ciVersionCode").orNull?.toIntOrNull()
         versionCode = ciVersionCode ?: (System.getenv("GITHUB_RUN_NUMBER") ?: "1").toInt()
-        versionName = "1.0"
+        versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -29,17 +29,17 @@ STAGED_KT=$(git diff --cached --name-only --diff-filter=ACM | grep '\.kt$' || tr
 STAGED_SWIFT=$(git diff --cached --name-only --diff-filter=ACM | grep '\.swift$' || true)
 STAGED_TS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|js)$' || true)
 STAGED_ALL=$(git diff --cached --name-only --diff-filter=ACM || true)
-STAGED_ICON_ASSETS=$(printf '%s\n' "$STAGED_ALL" | grep -E '(^|/)(AppIcon\.appiconset/|mipmap-(anydpi-v26|mdpi|hdpi|xhdpi|xxhdpi|xxxhdpi)/|values/ic_launcher_background\.xml$|scripts/sync_app_icons\.py$)' || true)
+STAGED_RELEASE_CONTRACT=$(printf '%s\n' "$STAGED_ALL" | grep -E '(^|/)(AppIcon\.appiconset/|mipmap-(anydpi-v26|mdpi|hdpi|xhdpi|xxhdpi|xxxhdpi)/|values/ic_launcher_background\.xml$|android/fastlane/metadata/|ios/OpenClawConsole/fastlane/metadata/|PRIVACY_POLICY\.md$|scripts/sync_app_icons\.py$|scripts/validate_release_contract\.py$|scripts/preflight-release\.sh$|\.github/workflows/(ci|store-listing-parity|native-release|internal-distribution)\.yml$)' || true)
 
 # ═══════════════════════════════════════════════════════════════════
 # OPENCLAW SECURITY PATTERNS
 # ═══════════════════════════════════════════════════════════════════
 
-if [ -n "$STAGED_ICON_ASSETS" ]; then
+if [ -n "$STAGED_RELEASE_CONTRACT" ]; then
   if ! command -v python3 > /dev/null 2>&1; then
-    err "python3 is required to validate app icon parity"
-  elif ! python3 scripts/sync_app_icons.py --check; then
-    err "App icon assets are out of sync with the canonical iOS marketing icon"
+    err "python3 is required to validate the release contract"
+  elif ! python3 scripts/validate_release_contract.py --platform both; then
+    err "Release contract validation failed"
   fi
 fi
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -5,8 +5,8 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-echo "==> Checking app icon parity"
-python3 scripts/sync_app_icons.py --check
+echo "==> Checking release contract"
+python3 scripts/validate_release_contract.py --platform both
 
 echo "==> Android unit tests + debug build"
 (

--- a/scripts/preflight-release.sh
+++ b/scripts/preflight-release.sh
@@ -1,75 +1,25 @@
 #!/usr/bin/env bash
 # preflight-release.sh — Pre-release validation for OpenClaw Work Console
-# Ensures store listing metadata, privacy policy, changelogs, and build
-# integrity are all present and correct before publishing.
-#
-# Usage:
-#   ./scripts/preflight-release.sh --platform android|ios|both [--layer 1|2]
-#
-# Layers:
-#   1 (default) — Metadata & file checks only (fast, no build)
-#   2           — Full validation including Gradle/Xcode builds
+# Delegates metadata/icon validation to scripts/validate_release_contract.py
+# and optionally runs platform builds for a deeper preflight.
 set -euo pipefail
-# ── Globals ──────────────────────────────────────────────────────────────────
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PLATFORM="both"
 LAYER=1
-ERRORS=()
-WARNINGS=()
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-GREEN='\033[0;32m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-RESET='\033[0m'
-# ── Helpers ──────────────────────────────────────────────────────────────────
+
 usage() {
 cat <<EOF
 Usage: $(basename "$0") [options]
 Options:
---platform   Target platform (required): android, ios, both
+--platform   Target platform: android, ios, both
 --layer      Validation depth: 1=metadata only, 2=metadata+build (default: 1)
 -h, --help   Show this help
 EOF
 exit 0
 }
-err() { ERRORS+=("$1"); echo -e "${RED}${BOLD}ERROR:${RESET} $1"; }
-warn() { WARNINGS+=("$1"); echo -e "${YELLOW}${BOLD}WARN:${RESET} $1"; }
-info() { echo -e "${CYAN}INFO:${RESET} $1"; }
-header() { echo -e "\n${BOLD}# $1${RESET}"; }
-check_file_exists() {
-local path="$1"
-if [[ ! -f "$path" ]]; then
-  err "Missing required file: $path"
-  return 1
-fi
-return 0
-}
-check_file_nonempty() {
-local path="$1"
-if [[ ! -f "$path" ]]; then
-  err "Missing required file: $path"
-  return 1
-fi
-if [[ ! -s "$path" ]]; then
-  err "Required file is empty: $path"
-  return 1
-fi
-return 0
-}
-check_dir_has_files() {
-local dir="$1"
-local min="$2"
-local count
-count=$(find "$dir" -maxdepth 1 -type f | wc -l)
-if (( count < min )); then
-  err "Directory $dir contains $count files (minimum $min required)"
-  return 1
-fi
-return 0
-}
-# ── Parse args ───────────────────────────────────────────────────────────────
+
 while [[ $# -gt 0 ]]; do
 case $1 in
   --platform) PLATFORM="$2"; shift 2 ;;
@@ -78,188 +28,47 @@ case $1 in
   *) echo "Unknown option: $1"; usage ;;
 esac
 done
-if [[ -z "$PLATFORM" ]]; then
-echo "Platform is required"
-exit 2
-fi
+
 if [[ ! "$PLATFORM" =~ ^(android|ios|both)$ ]]; then
-echo "Invalid platform"
-exit 2
+  echo "Invalid platform: $PLATFORM"
+  exit 2
 fi
-echo -e "${BOLD}OpenClaw Work Console Preflight Check${RESET}"
+
+echo "OpenClaw Work Console Preflight Check"
 echo "Platform: $PLATFORM"
 echo "Layer:    $LAYER"
-# ── Extract versions ─────────────────────────────────────────────────────────
-header "Version Extraction"
-ANDROID_VERSION_NAME="unknown"
-ANDROID_VERSION_CODE="unknown"
-IOS_VERSION_NAME="unknown"
-IOS_BUILD_NUMBER="unknown"
-GRADLE_FILE="$PROJECT_ROOT/android/app/build.gradle.kts"
-if [[ -f "$GRADLE_FILE" ]]; then
-ANDROID_VERSION_NAME=$(sed -n 's/.*versionName *= *"\([^"]*\)".*/\1/p' "$GRADLE_FILE")
-ANDROID_VERSION_CODE=$(sed -n 's/.*versionCode *= *\([0-9]*\).*/\1/p' "$GRADLE_FILE")
-info "Android: $ANDROID_VERSION_NAME ($ANDROID_VERSION_CODE)"
-fi
-PBXPROJ="$PROJECT_ROOT/ios/OpenClawConsole/OpenClawConsole.xcodeproj/project.pbxproj"
-if [[ -f "$PBXPROJ" ]]; then
-IOS_VERSION_NAME=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | cut -d'=' -f2 | tr -d ' ;')
-IOS_BUILD_NUMBER=$(grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | cut -d'=' -f2 | tr -d ' ;')
-info "iOS:     $IOS_VERSION_NAME ($IOS_BUILD_NUMBER)"
-else
-IOS_INFO_PLIST="$PROJECT_ROOT/ios/OpenClawConsole/OpenClawConsole/Info.plist"
-if [[ -f "$IOS_INFO_PLIST" ]]; then
-  IOS_VERSION_NAME=$(plutil -extract CFBundleShortVersionString raw "$IOS_INFO_PLIST" 2>/dev/null || true)
-  IOS_BUILD_NUMBER=$(plutil -extract CFBundleVersion raw "$IOS_INFO_PLIST" 2>/dev/null || true)
-  info "iOS (Info.plist): $IOS_VERSION_NAME ($IOS_BUILD_NUMBER)"
-fi
-fi
-# Cross-platform version parity warning
-if [[ -n "$ANDROID_VERSION_NAME" && -n "$IOS_VERSION_NAME" ]]; then
-if [[ "$ANDROID_VERSION_NAME" != "$IOS_VERSION_NAME" ]]; then
-  warn "Version name mismatch! Android: $ANDROID_VERSION_NAME vs iOS: $IOS_VERSION_NAME"
-fi
-fi
-# ══════════════════════════════════════════════════════════════════════════════
-# LAYER 1 — Metadata & File Checks
-# ══════════════════════════════════════════════════════════════════════════════
-# ── Privacy Policy ───────────────────────────────────────────────────────────
-header "Privacy Policy Check"
-PRIVACY_FILE="$PROJECT_ROOT/PRIVACY_POLICY.md"
-if check_file_nonempty "$PRIVACY_FILE"; then
-info "Privacy policy found and non-empty"
-else
-  err "Privacy policy missing or empty"
-fi
-# ── Android Metadata ─────────────────────────────────────────────────────────
-if [[ "$PLATFORM" == "android" || "$PLATFORM" == "both" ]]; then
-header "Android Store Metadata Check"
-ANDROID_META="$PROJECT_ROOT/android/fastlane/metadata/android/en-US"
-# Required text files
-for f in title.txt short_description.txt full_description.txt; do
-  check_file_nonempty "$ANDROID_META/$f"
-done
-# Changelog for current version code
-if [[ -n "$ANDROID_VERSION_CODE" ]]; then
-  CHANGELOG="$ANDROID_META/changelogs/$ANDROID_VERSION_CODE.txt"
-  if check_file_nonempty "$CHANGELOG"; then
-    info "Android changelog found for version $ANDROID_VERSION_CODE"
-  fi
-else
-  warn "Android version code unknown, skipping changelog check"
-fi
-# Screenshots
-SCREENSHOTS_DIR="$PROJECT_ROOT/android/fastlane/metadata/android/en-US/images/phoneScreenshots"
-if [[ -d "$SCREENSHOTS_DIR" ]]; then
-  check_dir_has_files "$SCREENSHOTS_DIR" 2
-  SHOT_COUNT=$(find "$SCREENSHOTS_DIR" -maxdepth 1 -type f | wc -l)
-  info "Found $SHOT_COUNT Android phone screenshots"
-else
-  warn "Android phone screenshots directory exists but is empty (add screenshots before production release)"
-fi
-# Description length checks
-if [[ -f "$ANDROID_META/short_description.txt" ]]; then
-  SHORT_LEN=$(wc -c < "$ANDROID_META/short_description.txt")
-  if (( SHORT_LEN > 80 )); then
-    err "Android short description exceeds 80 chars ($SHORT_LEN)"
-  fi
-fi
-if [[ -f "$ANDROID_META/title.txt" ]]; then
-  TITLE_LEN=$(wc -c < "$ANDROID_META/title.txt")
-  if (( TITLE_LEN > 30 )); then
-    err "Android title exceeds 30 chars ($TITLE_LEN)"
-  fi
-fi
-fi
-# ── iOS Metadata ─────────────────────────────────────────────────────────────
-if [[ "$PLATFORM" == "ios" || "$PLATFORM" == "both" ]]; then
-header "iOS App Store Metadata Check"
-IOS_META="$PROJECT_ROOT/ios/OpenClawConsole/fastlane/metadata"
-# Required text files
-for f in name.txt subtitle.txt description.txt keywords.txt release_notes.txt; do
-  check_file_nonempty "$IOS_META/en-US/$f"
-done
-# Privacy URL (required by App Store)
-if check_file_nonempty "$IOS_META/en-US/privacy_url.txt"; then
-  PRIVACY_URL=$(cat "$IOS_META/en-US/privacy_url.txt")
-  if [[ ! "$PRIVACY_URL" =~ ^https:// ]]; then
-    err "iOS privacy_url.txt must start with https://"
-  fi
-fi
-# Support URL
-check_file_nonempty "$IOS_META/en-US/support_url.txt"
-# Field length checks
-if [[ -f "$IOS_META/en-US/name.txt" ]]; then
-  NAME_LEN=$(wc -c < "$IOS_META/en-US/name.txt")
-  if (( NAME_LEN > 30 )); then
-    err "iOS app name exceeds 30 chars ($NAME_LEN)"
-  fi
-fi
-if [[ -f "$IOS_META/en-US/subtitle.txt" ]]; then
-  SUB_LEN=$(wc -c < "$IOS_META/en-US/subtitle.txt")
-  if (( SUB_LEN > 30 )); then
-    err "iOS subtitle exceeds 30 chars ($SUB_LEN)"
-  fi
-fi
-if [[ -f "$IOS_META/en-US/keywords.txt" ]]; then
-  KW_LEN=$(wc -c < "$IOS_META/en-US/keywords.txt")
-  if (( KW_LEN > 100 )); then
-    err "iOS keywords exceed 100 chars ($KW_LEN)"
-  fi
-fi
-fi
-# ══════════════════════════════════════════════════════════════════════════════
-# LAYER 2 — Build Validation (optional)
-# ══════════════════════════════════════════════════════════════════════════════
+
+python3 "$PROJECT_ROOT/scripts/validate_release_contract.py" --platform "$PLATFORM"
+
 if [[ "$LAYER" == "2" ]]; then
-if [[ "$PLATFORM" == "android" || "$PLATFORM" == "both" ]]; then
-  header "Android Build Check (Layer 2)"
-  info "Running lintDebug..."
-  if (cd "$PROJECT_ROOT/android" && ./gradlew lintDebug -quiet); then
-    info "Android lint passed"
-  else
-    err "Android lint failed"
+  if [[ "$PLATFORM" == "android" || "$PLATFORM" == "both" ]]; then
+    echo ""
+    echo "# Android Build Check (Layer 2)"
+    echo "INFO: Running lintDebug..."
+    (
+      cd "$PROJECT_ROOT/android"
+      ./gradlew lintDebug -quiet
+    )
+    echo "INFO: Android lint passed"
+  fi
+
+  if [[ "$PLATFORM" == "ios" || "$PLATFORM" == "both" ]]; then
+    echo ""
+    echo "# iOS Build Check (Layer 2)"
+    echo "INFO: Running Xcode build (simulator/no-sign)..."
+    (
+      cd "$PROJECT_ROOT/ios/OpenClawConsole"
+      xcodebuild build \
+        -scheme OpenClawConsole \
+        -destination 'generic/platform=iOS Simulator' \
+        CODE_SIGN_IDENTITY="" \
+        CODE_SIGNING_REQUIRED=NO \
+        CODE_SIGNING_ALLOWED=NO \
+        -quiet
+    )
+    echo "INFO: iOS build passed"
   fi
 fi
-if [[ "$PLATFORM" == "ios" || "$PLATFORM" == "both" ]]; then
-  header "iOS Build Check (Layer 2)"
-  info "Running Xcode build (simulator/no-sign)..."
-  SCHEME="OpenClawConsole"
-  if (cd "$PROJECT_ROOT/ios/OpenClawConsole" && xcodebuild build \
-    -scheme "$SCHEME" \
-    -destination 'generic/platform=iOS Simulator' \
-    CODE_SIGN_IDENTITY="" \
-    CODE_SIGNING_REQUIRED=NO \
-    CODE_SIGNING_ALLOWED=NO \
-    -quiet 2>&1); then
-    info "iOS build passed"
-  else
-    err "iOS build failed"
-  fi
-fi
-fi
-# ══════════════════════════════════════════════════════════════════════════════
-# RESULTS
-# ══════════════════════════════════════════════════════════════════════════════
-header "Validation Summary"
-if [[ ${#WARNINGS[@]} -gt 0 ]]; then
-echo -e "${YELLOW}${BOLD}Warnings:${RESET}"
-for w in "${WARNINGS[@]}"; do
-  echo -e "  - $w"
-done
-fi
-if [[ ${#ERRORS[@]} -gt 0 ]]; then
-echo -e "${RED}${BOLD}Errors:${RESET}"
-for e in "${ERRORS[@]}"; do
-  echo -e "  - $e"
-done
-echo
-echo -e "${RED}${BOLD}Preflight failed.${RESET} Please resolve errors before merging to main."
-exit 1
-fi
-echo
-echo -e "${GREEN}${BOLD}Preflight check passed!${RESET} Ready for release."
-if [[ ${#WARNINGS[@]} -gt 0 ]]; then
-echo -e "${YELLOW}Review warnings above before proceeding.${RESET}"
-fi
-exit 0
+
+echo ""
+echo "Preflight passed."

--- a/scripts/validate_release_contract.py
+++ b/scripts/validate_release_contract.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Validate OpenClaw's release contract across icons, metadata, and release inputs."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ANDROID_METADATA = ROOT / "android/fastlane/metadata/android/en-US"
+IOS_METADATA = ROOT / "ios/OpenClawConsole/fastlane/metadata/en-US"
+ANDROID_GRADLE = ROOT / "android/app/build.gradle.kts"
+IOS_PBXPROJ = ROOT / "ios/OpenClawConsole/OpenClawConsole.xcodeproj/project.pbxproj"
+PRIVACY_POLICY = ROOT / "PRIVACY_POLICY.md"
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+    def warn(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def note(self, message: str) -> None:
+        self.notes.append(message)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--platform",
+        choices=("android", "ios", "both"),
+        default="both",
+        help="Release surface to validate.",
+    )
+    parser.add_argument(
+        "--strict-screenshots",
+        action="store_true",
+        help="Treat missing screenshot directories as errors instead of warnings.",
+    )
+    return parser.parse_args()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def validate_nonempty_file(result: ValidationResult, path: Path, label: str) -> str | None:
+    if not path.is_file():
+        result.error(f"Missing required {label}: {path.relative_to(ROOT)}")
+        return None
+
+    content = read_text(path)
+    if not content:
+        result.error(f"Required {label} is empty: {path.relative_to(ROOT)}")
+        return None
+    return content
+
+
+def validate_max_length(
+    result: ValidationResult,
+    label: str,
+    value: str | None,
+    limit: int,
+) -> None:
+    if value is None:
+        return
+    if len(value) > limit:
+        result.error(f"{label} exceeds {limit} characters ({len(value)})")
+
+
+def validate_https_url(result: ValidationResult, path: Path, label: str) -> str | None:
+    value = validate_nonempty_file(result, path, label)
+    if value is None:
+        return None
+    if not value.startswith("https://"):
+        result.error(f"{label} must start with https://: {path.relative_to(ROOT)}")
+    return value
+
+
+def find_first(pattern: str, text: str) -> str | None:
+    match = re.search(pattern, text, re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+
+def android_version_info() -> tuple[str | None, str | None, bool]:
+    if not ANDROID_GRADLE.is_file():
+        return None, None, False
+
+    content = ANDROID_GRADLE.read_text(encoding="utf-8")
+    version_name = find_first(r'versionName\s*=\s*"([^"]+)"', content)
+    version_code = find_first(r"versionCode\s*=\s*([0-9]+)", content)
+    is_dynamic = "ciVersionCode ?:" in content or 'System.getenv("GITHUB_RUN_NUMBER")' in content
+    return version_name, version_code, is_dynamic
+
+
+def ios_version_info() -> tuple[str | None, str | None]:
+    if not IOS_PBXPROJ.is_file():
+        return None, None
+
+    content = IOS_PBXPROJ.read_text(encoding="utf-8")
+    marketing_version = find_first(r"MARKETING_VERSION = ([^;]+);", content)
+    build_number = find_first(r"CURRENT_PROJECT_VERSION = ([^;]+);", content)
+    return marketing_version, build_number
+
+
+def check_icon_parity(result: ValidationResult) -> None:
+    command = [sys.executable, str(ROOT / "scripts/sync_app_icons.py"), "--check"]
+    run = subprocess.run(command, capture_output=True, text=True, cwd=ROOT)
+    if run.returncode == 0:
+        summary = run.stdout.strip() or "App icon assets match the canonical iOS marketing icon."
+        result.note(summary)
+        return
+
+    stderr = run.stderr.strip()
+    stdout = run.stdout.strip()
+    details = "\n".join(part for part in (stdout, stderr) if part)
+    if details:
+        for line in details.splitlines():
+            result.error(line)
+    else:
+        result.error("App icon parity validation failed.")
+
+
+def check_privacy_policy(result: ValidationResult) -> None:
+    validate_nonempty_file(result, PRIVACY_POLICY, "privacy policy")
+
+
+def check_android(result: ValidationResult, strict_screenshots: bool) -> None:
+    title = validate_nonempty_file(result, ANDROID_METADATA / "title.txt", "Android title")
+    short_description = validate_nonempty_file(
+        result,
+        ANDROID_METADATA / "short_description.txt",
+        "Android short description",
+    )
+    validate_nonempty_file(result, ANDROID_METADATA / "full_description.txt", "Android full description")
+
+    validate_max_length(result, "Android title", title, 30)
+    validate_max_length(result, "Android short description", short_description, 80)
+
+    version_name, version_code, is_dynamic = android_version_info()
+    if version_name:
+        result.note(f"Android versionName={version_name}")
+    if version_code:
+        changelog = ANDROID_METADATA / "changelogs" / f"{version_code}.txt"
+        validate_nonempty_file(result, changelog, f"Android changelog for versionCode {version_code}")
+    else:
+        changelog_dir = ANDROID_METADATA / "changelogs"
+        changelog_files = sorted(changelog_dir.glob("*.txt")) if changelog_dir.is_dir() else []
+        if not changelog_files:
+            result.error("Android changelogs directory has no changelog files.")
+        else:
+            latest = changelog_files[-1]
+            validate_nonempty_file(result, latest, "Android changelog")
+            if is_dynamic:
+                result.warn(
+                    "Android versionCode is dynamic; validated the latest tracked changelog instead of an exact versionCode match."
+                )
+            else:
+                result.warn("Android versionCode could not be determined exactly from build.gradle.kts.")
+
+    screenshots_dir = ANDROID_METADATA / "images/phoneScreenshots"
+    if screenshots_dir.is_dir():
+        screenshot_count = len([path for path in screenshots_dir.iterdir() if path.is_file()])
+        if screenshot_count < 2:
+            message = (
+                f"Android phone screenshots directory contains {screenshot_count} files; expected at least 2."
+            )
+            if strict_screenshots:
+                result.error(message)
+            else:
+                result.warn(message)
+        else:
+            result.note(f"Android phone screenshots: {screenshot_count}")
+    else:
+        message = "Android phone screenshots directory is missing: android/fastlane/metadata/android/en-US/images/phoneScreenshots"
+        if strict_screenshots:
+            result.error(message)
+        else:
+            result.warn(message)
+
+
+def check_ios(result: ValidationResult, strict_screenshots: bool) -> None:
+    name = validate_nonempty_file(result, IOS_METADATA / "name.txt", "iOS app name")
+    subtitle = validate_nonempty_file(result, IOS_METADATA / "subtitle.txt", "iOS subtitle")
+    keywords = validate_nonempty_file(result, IOS_METADATA / "keywords.txt", "iOS keywords")
+
+    for filename, label in (
+        ("description.txt", "iOS description"),
+        ("release_notes.txt", "iOS release notes"),
+    ):
+        validate_nonempty_file(result, IOS_METADATA / filename, label)
+
+    validate_https_url(result, IOS_METADATA / "privacy_url.txt", "iOS privacy URL")
+    validate_https_url(result, IOS_METADATA / "support_url.txt", "iOS support URL")
+    validate_https_url(result, IOS_METADATA / "marketing_url.txt", "iOS marketing URL")
+
+    validate_max_length(result, "iOS app name", name, 30)
+    validate_max_length(result, "iOS subtitle", subtitle, 30)
+    validate_max_length(result, "iOS keywords", keywords, 100)
+
+    marketing_version, build_number = ios_version_info()
+    if marketing_version:
+        result.note(f"iOS marketingVersion={marketing_version}")
+    if build_number:
+        result.note(f"iOS buildNumber={build_number}")
+
+    screenshots_root = ROOT / "ios/OpenClawConsole/fastlane/screenshots"
+    locale_dir = screenshots_root / "en-US"
+    candidate_dir = locale_dir if locale_dir.is_dir() else screenshots_root
+    if candidate_dir.is_dir():
+        screenshot_count = len([path for path in candidate_dir.rglob("*") if path.is_file()])
+        if screenshot_count == 0:
+            message = "iOS fastlane screenshots directory exists but has no files."
+            if strict_screenshots:
+                result.error(message)
+            else:
+                result.warn(message)
+        else:
+            result.note(f"iOS screenshots: {screenshot_count}")
+    else:
+        message = "iOS fastlane screenshots directory is missing: ios/OpenClawConsole/fastlane/screenshots"
+        if strict_screenshots:
+            result.error(message)
+        else:
+            result.warn(message)
+
+
+def check_cross_platform_parity(result: ValidationResult) -> None:
+    android_title = validate_nonempty_file(result, ANDROID_METADATA / "title.txt", "Android title")
+    ios_name = validate_nonempty_file(result, IOS_METADATA / "name.txt", "iOS app name")
+    if android_title and ios_name and android_title != ios_name:
+        result.error(f"App name mismatch: Android '{android_title}' vs iOS '{ios_name}'")
+
+    android_version_name, _, _ = android_version_info()
+    ios_marketing_version, _ = ios_version_info()
+    if android_version_name and ios_marketing_version and android_version_name != ios_marketing_version:
+        result.warn(
+            f"Version name mismatch: Android {android_version_name} vs iOS {ios_marketing_version}"
+        )
+
+
+def render(result: ValidationResult) -> int:
+    print("OpenClaw release contract")
+    print(f"Repo: {ROOT}")
+
+    if result.notes:
+        print("\nNotes:")
+        for note in result.notes:
+            print(f" - {note}")
+
+    if result.warnings:
+        print("\nWarnings:")
+        for warning in result.warnings:
+            print(f" - {warning}")
+
+    if result.errors:
+        print("\nErrors:")
+        for error in result.errors:
+            print(f" - {error}")
+        print(f"\nRelease contract failed with {len(result.errors)} error(s).")
+        return 1
+
+    warning_summary = f" with {len(result.warnings)} warning(s)" if result.warnings else ""
+    print(f"\nRelease contract passed{warning_summary}.")
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    result = ValidationResult()
+
+    check_privacy_policy(result)
+    check_icon_parity(result)
+
+    if args.platform in {"android", "both"}:
+        check_android(result, args.strict_screenshots)
+    if args.platform in {"ios", "both"}:
+        check_ios(result, args.strict_screenshots)
+    if args.platform == "both":
+        check_cross_platform_parity(result)
+
+    return render(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a single release-contract validator for icons, store metadata, privacy policy, changelogs, and cross-platform naming/version parity
- wire the validator into preflight, hooks, CI, and store-listing parity checks
- run preflight consistently in native/internal distribution workflows after Python/Pillow setup
- align Android versionName with iOS marketing version

## Verification
- python3 scripts/validate_release_contract.py --platform both
- bash scripts/preflight-release.sh --platform both --layer 1
- cd android && ./gradlew testDebugUnitTest assembleDebug --no-daemon
- pre-push verification passed (release contract, Android build, skills tests)

## Known warnings
- Android fastlane screenshots directory is still missing
- iOS fastlane screenshots directory is still missing
- Android versionCode remains dynamic, so changelog validation uses the latest tracked changelog file