### PR TITLE
feat: add operator summary feed for dashboards

### DIFF
--- a/openclaw-skills/src/gateway/operator-summary.ts
+++ b/openclaw-skills/src/gateway/operator-summary.ts
@@ -1,0 +1,278 @@
+import type { GatewayConfig } from '../config/default.js';
+import type { BridgeSession, Incident, ApprovalRequest, Task, Agent, OperatorSummaryResponse, OperatorSummaryCounts, OperatorSummaryAgent, OperatorSummaryApproval, OperatorSummaryBridge, OperatorSummaryIncident, OperatorSummaryTask } from '../types/protocol.js';
+import type { StateManager } from './state.js';
+import type { WebSocketRuntimeSnapshot } from './websocket.js';
+
+const AGENT_STALE_AFTER_MS = 15 * 60 * 1000;
+const BRIDGE_STALE_AFTER_MS = 10 * 60 * 1000;
+const DEFAULT_LIMIT = 5;
+
+interface BuildOperatorSummaryParams {
+  config: GatewayConfig;
+  state: StateManager;
+  startedAtIso: string;
+  wsSnapshot: WebSocketRuntimeSnapshot;
+  now?: Date;
+  limit?: number;
+}
+
+function parseTime(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function minutesSince(value: string | null | undefined, nowMs: number): number | null {
+  const parsed = parseTime(value);
+  if (parsed === null) return null;
+  return Math.max(0, Math.floor((nowMs - parsed) / 60_000));
+}
+
+function severityRank(severity: Incident['severity']): number {
+  if (severity === 'critical') return 0;
+  if (severity === 'warning') return 1;
+  return 2;
+}
+
+function statusRank(status: Task['status']): number {
+  if (status === 'failed') return 0;
+  if (status === 'running') return 1;
+  if (status === 'queued') return 2;
+  return 3;
+}
+
+function clampLimit(raw: number | undefined): number {
+  if (!Number.isInteger(raw) || !raw) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(10, raw));
+}
+
+function summarizeAgent(agent: Agent, nowMs: number): OperatorSummaryAgent {
+  const lastSeenMinutes = minutesSince(agent.last_active, nowMs);
+  const stale = lastSeenMinutes !== null && lastSeenMinutes >= 15;
+  return {
+    id: agent.id,
+    name: agent.name,
+    status: agent.status,
+    last_active: agent.last_active,
+    last_active_minutes_ago: lastSeenMinutes,
+    stale,
+    active_tasks: agent.active_tasks,
+    pending_approvals: agent.pending_approvals,
+    workspace: agent.workspace,
+    current_branch: agent.git_state?.current_branch ?? null,
+    uncommitted_changes: agent.git_state?.uncommitted_changes ?? 0,
+    ahead_by: agent.git_state?.ahead_by ?? 0,
+    behind_by: agent.git_state?.behind_by ?? 0,
+  };
+}
+
+function summarizeTask(task: Task): OperatorSummaryTask {
+  const latestStep = task.steps.at(-1);
+  return {
+    id: task.id,
+    agent_id: task.agent_id,
+    title: task.title,
+    status: task.status,
+    updated_at: task.updated_at,
+    step_count: task.steps.length,
+    latest_step_type: latestStep?.type ?? null,
+    latest_step_preview: latestStep?.content.slice(0, 140) ?? null,
+  };
+}
+
+function summarizeIncident(incident: Incident): OperatorSummaryIncident {
+  return {
+    id: incident.id,
+    agent_id: incident.agent_id,
+    agent_name: incident.agent_name,
+    severity: incident.severity,
+    status: incident.status,
+    title: incident.title,
+    updated_at: incident.updated_at,
+  };
+}
+
+function summarizeApproval(approval: ApprovalRequest): OperatorSummaryApproval {
+  return {
+    id: approval.id,
+    agent_id: approval.agent_id,
+    agent_name: approval.agent_name,
+    action_type: approval.action_type,
+    title: approval.title,
+    created_at: approval.created_at,
+    expires_at: approval.expires_at,
+    risk_level: approval.context.risk_level,
+    environment: approval.context.environment,
+    service: approval.context.service,
+  };
+}
+
+function summarizeBridge(bridge: BridgeSession, nowMs: number): OperatorSummaryBridge {
+  const updatedMinutes = minutesSince(bridge.updated_at, nowMs);
+  return {
+    id: bridge.id,
+    agent_id: bridge.agent_id,
+    title: bridge.title,
+    type: bridge.type,
+    cwd: bridge.cwd,
+    closed: bridge.closed,
+    updated_at: bridge.updated_at,
+    updated_minutes_ago: updatedMinutes,
+    stale: !bridge.closed && updatedMinutes !== null && updatedMinutes >= 10,
+  };
+}
+
+function buildCounts(agents: Agent[], tasks: Task[], incidents: Incident[], approvals: ApprovalRequest[], bridges: BridgeSession[], wsSnapshot: WebSocketRuntimeSnapshot, nowMs: number): OperatorSummaryCounts {
+  const openIncidents = incidents.filter((incident) => incident.status === 'open');
+  const openBridges = bridges.filter((bridge) => !bridge.closed);
+  return {
+    agents_total: agents.length,
+    agents_online: agents.filter((agent) => agent.status === 'online').length,
+    agents_busy: agents.filter((agent) => agent.status === 'busy').length,
+    agents_offline: agents.filter((agent) => agent.status === 'offline').length,
+    agents_stale: agents.filter((agent) => {
+      const lastActive = parseTime(agent.last_active);
+      return lastActive !== null && nowMs - lastActive >= AGENT_STALE_AFTER_MS;
+    }).length,
+    tasks_running: tasks.filter((task) => task.status === 'running').length,
+    tasks_queued: tasks.filter((task) => task.status === 'queued').length,
+    tasks_failed: tasks.filter((task) => task.status === 'failed').length,
+    approvals_pending: approvals.length,
+    incidents_open: openIncidents.length,
+    incidents_critical: openIncidents.filter((incident) => incident.severity === 'critical').length,
+    bridges_open: openBridges.length,
+    bridges_stale: openBridges.filter((bridge) => {
+      const updatedAt = parseTime(bridge.updated_at);
+      return updatedAt !== null && nowMs - updatedAt >= BRIDGE_STALE_AFTER_MS;
+    }).length,
+    websocket_clients: wsSnapshot.connected_clients,
+  };
+}
+
+function buildHeadline(counts: OperatorSummaryCounts): string {
+  if (counts.incidents_critical > 0) {
+    return `${counts.incidents_critical} critical incident${counts.incidents_critical === 1 ? '' : 's'} need attention`;
+  }
+  if (counts.approvals_pending > 0) {
+    return `${counts.approvals_pending} approval${counts.approvals_pending === 1 ? '' : 's'} waiting for review`;
+  }
+  if (counts.tasks_failed > 0) {
+    return `${counts.tasks_failed} failed task${counts.tasks_failed === 1 ? '' : 's'} need triage`;
+  }
+  return `System nominal: ${counts.agents_online}/${counts.agents_total} agents online, ${counts.tasks_running} task${counts.tasks_running === 1 ? '' : 's'} running`;
+}
+
+function buildAttentionLines(counts: OperatorSummaryCounts): string[] {
+  const lines: string[] = [];
+  if (counts.incidents_critical > 0) {
+    lines.push(`${counts.incidents_critical} critical incident${counts.incidents_critical === 1 ? '' : 's'} open`);
+  }
+  if (counts.approvals_pending > 0) {
+    lines.push(`${counts.approvals_pending} pending approval${counts.approvals_pending === 1 ? '' : 's'}`);
+  }
+  if (counts.tasks_failed > 0) {
+    lines.push(`${counts.tasks_failed} failed task${counts.tasks_failed === 1 ? '' : 's'}`);
+  }
+  if (counts.agents_offline > 0) {
+    lines.push(`${counts.agents_offline} agent${counts.agents_offline === 1 ? '' : 's'} offline`);
+  }
+  if (counts.bridges_stale > 0) {
+    lines.push(`${counts.bridges_stale} stale bridge session${counts.bridges_stale === 1 ? '' : 's'}`);
+  }
+  return lines;
+}
+
+function buildSummaryLines(counts: OperatorSummaryCounts): string[] {
+  const lines = buildAttentionLines(counts);
+  if (lines.length > 0) {
+    return lines;
+  }
+  return [
+    `${counts.agents_online}/${counts.agents_total} agents online`,
+    `${counts.tasks_running} running task${counts.tasks_running === 1 ? '' : 's'}, ${counts.tasks_queued} queued`,
+    `${counts.websocket_clients} websocket client${counts.websocket_clients === 1 ? '' : 's'} connected`,
+  ];
+}
+
+export function buildOperatorSummary({
+  config,
+  state,
+  startedAtIso,
+  wsSnapshot,
+  now = new Date(),
+  limit,
+}: BuildOperatorSummaryParams): OperatorSummaryResponse {
+  const nowMs = now.getTime();
+  const cappedLimit = clampLimit(limit);
+  const agents = state.listAgents();
+  const tasks = state.listAllTasks();
+  const incidents = state.listIncidents();
+  const approvals = state.listPendingApprovals();
+  const bridges = state.listBridgeSessions();
+
+  const counts = buildCounts(agents, tasks, incidents, approvals, bridges, wsSnapshot, nowMs);
+  const attention = buildAttentionLines(counts);
+  const summaryLines = buildSummaryLines(counts);
+
+  return {
+    checked_at: now.toISOString(),
+    started_at: startedAtIso,
+    approval_policy_preset: config.approvalPolicyPreset,
+    headline: buildHeadline(counts),
+    needs_attention: attention,
+    summary_lines: summaryLines,
+    counts,
+    agents: [...agents]
+      .sort((left, right) => {
+        const leftSummary = summarizeAgent(left, nowMs);
+        const rightSummary = summarizeAgent(right, nowMs);
+        const leftScore = (leftSummary.status === 'offline' ? 100 : 0)
+          + (leftSummary.stale ? 50 : 0)
+          + leftSummary.pending_approvals * 10
+          + leftSummary.active_tasks;
+        const rightScore = (rightSummary.status === 'offline' ? 100 : 0)
+          + (rightSummary.stale ? 50 : 0)
+          + rightSummary.pending_approvals * 10
+          + rightSummary.active_tasks;
+        return rightScore - leftScore;
+      })
+      .slice(0, cappedLimit)
+      .map((agent) => summarizeAgent(agent, nowMs)),
+    tasks: [...tasks]
+      .sort((left, right) => {
+        const rankDelta = statusRank(left.status) - statusRank(right.status);
+        if (rankDelta !== 0) return rankDelta;
+        return right.updated_at.localeCompare(left.updated_at);
+      })
+      .slice(0, cappedLimit)
+      .map(summarizeTask),
+    incidents: incidents
+      .filter((incident) => incident.status === 'open')
+      .sort((left, right) => {
+        const rankDelta = severityRank(left.severity) - severityRank(right.severity);
+        if (rankDelta !== 0) return rankDelta;
+        return right.updated_at.localeCompare(left.updated_at);
+      })
+      .slice(0, cappedLimit)
+      .map(summarizeIncident),
+    approvals: [...approvals]
+      .sort((left, right) => right.created_at.localeCompare(left.created_at))
+      .slice(0, cappedLimit)
+      .map(summarizeApproval),
+    bridges: bridges
+      .sort((left, right) => {
+        if (left.closed !== right.closed) return Number(left.closed) - Number(right.closed);
+        return right.updated_at.localeCompare(left.updated_at);
+      })
+      .slice(0, cappedLimit)
+      .map((bridge) => summarizeBridge(bridge, nowMs)),
+    websocket: {
+      gateway_version: config.version,
+      connected_clients: wsSnapshot.connected_clients,
+      last_inbound_at: wsSnapshot.last_inbound_at,
+      last_outbound_at: wsSnapshot.last_outbound_at,
+      uptime_seconds: Math.max(0, Math.floor((nowMs - Date.parse(startedAtIso)) / 1000)),
+      sessions: wsSnapshot.sessions,
+    },
+  };
+}

--- a/openclaw-skills/src/gateway/server.ts
+++ b/openclaw-skills/src/gateway/server.ts
@@ -23,6 +23,7 @@ import type {
   ChatRequest,
   ApprovalRespondRequest,
   HealthResponse,
+  OperatorSummaryResponse,
   ApprovalResponse,
   RuntimeConfigResponse,
   RuntimeConfigUpdateRequest,
@@ -37,6 +38,7 @@ import { createIntegrationsRouter } from '../integrations/devops-hub.js';
 import { getConfiguredLocalModel, probeLocalModelProvider } from './model-provider.js';
 import { isApprovalPolicyPreset } from '../config/default.js';
 import { normalizeProjectBridgeSession } from './project-session.js';
+import { buildOperatorSummary } from './operator-summary.js';
 
 export interface GatewayServer {
   httpServer: http.Server;
@@ -120,6 +122,18 @@ export function createGatewayServer(
       },
       local_model: getConfiguredLocalModel(config),
     });
+  });
+
+  app.get('/api/dashboard/summary', auth, (req: Request, res: Response) => {
+    const rawLimit = Number.parseInt(String(req.query['limit'] ?? ''), 10);
+    const body: OperatorSummaryResponse = buildOperatorSummary({
+      config,
+      state,
+      startedAtIso,
+      wsSnapshot: wsManager.getRuntimeSnapshot(),
+      limit: Number.isNaN(rawLimit) ? undefined : rawLimit,
+    });
+    res.json(body);
   });
 
   app.get('/api/model/status', auth, async (_req: Request, res: Response) => {

--- a/openclaw-skills/src/types/protocol.ts
+++ b/openclaw-skills/src/types/protocol.ts
@@ -473,6 +473,108 @@ export interface HealthResponse {
   };
 }
 
+export interface OperatorSummaryCounts {
+  agents_total: number;
+  agents_online: number;
+  agents_busy: number;
+  agents_offline: number;
+  agents_stale: number;
+  tasks_running: number;
+  tasks_queued: number;
+  tasks_failed: number;
+  approvals_pending: number;
+  incidents_open: number;
+  incidents_critical: number;
+  bridges_open: number;
+  bridges_stale: number;
+  websocket_clients: number;
+}
+
+export interface OperatorSummaryAgent {
+  id: string;
+  name: string;
+  status: AgentStatus;
+  last_active: string;
+  last_active_minutes_ago: number | null;
+  stale: boolean;
+  active_tasks: number;
+  pending_approvals: number;
+  workspace: string;
+  current_branch: string | null;
+  uncommitted_changes: number;
+  ahead_by: number;
+  behind_by: number;
+}
+
+export interface OperatorSummaryTask {
+  id: string;
+  agent_id: string;
+  title: string;
+  status: TaskStatus;
+  updated_at: string;
+  step_count: number;
+  latest_step_type: StepType | null;
+  latest_step_preview: string | null;
+}
+
+export interface OperatorSummaryIncident {
+  id: string;
+  agent_id: string;
+  agent_name: string;
+  severity: IncidentSeverity;
+  status: IncidentStatus;
+  title: string;
+  updated_at: string;
+}
+
+export interface OperatorSummaryApproval {
+  id: string;
+  agent_id: string;
+  agent_name: string;
+  action_type: ActionType;
+  title: string;
+  created_at: string;
+  expires_at: string;
+  risk_level: RiskLevel;
+  environment: string;
+  service: string;
+}
+
+export interface OperatorSummaryBridge {
+  id: string;
+  agent_id: string;
+  title: string;
+  type: BridgeSession['type'];
+  cwd: string;
+  closed: boolean;
+  updated_at: string;
+  updated_minutes_ago: number | null;
+  stale: boolean;
+}
+
+export interface OperatorSummaryResponse {
+  checked_at: string;
+  started_at: string;
+  approval_policy_preset: string;
+  headline: string;
+  needs_attention: string[];
+  summary_lines: string[];
+  counts: OperatorSummaryCounts;
+  agents: OperatorSummaryAgent[];
+  tasks: OperatorSummaryTask[];
+  incidents: OperatorSummaryIncident[];
+  approvals: OperatorSummaryApproval[];
+  bridges: OperatorSummaryBridge[];
+  websocket: GatewayHeartbeatPayload & {
+    sessions: Array<{
+      id: string;
+      connected_at: string;
+      last_message_at: string | null;
+      subscribed_agents: string[];
+    }>;
+  };
+}
+
 // ─── Error Codes ─────────────────────────────────────────────────────────────
 
 export const ERROR_CODES = {

--- a/openclaw-skills/tests/operator-summary.test.ts
+++ b/openclaw-skills/tests/operator-summary.test.ts
@@ -1,0 +1,207 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, test } from '@jest/globals';
+import DEFAULT_CONFIG from '../src/config/default.js';
+import { StateManager } from '../src/gateway/state.js';
+import { createGatewayServer, type GatewayServer } from '../src/gateway/server.js';
+import type { GatewayConfig, ApprovalPolicyPreset } from '../src/config/default.js';
+import type { ApprovalRequest, BridgeSession, OperatorSummaryResponse } from '../src/types/protocol.js';
+
+const servers: GatewayServer[] = [];
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    await servers.pop()?.stop();
+  }
+});
+
+function tempConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    host: '127.0.0.1',
+    port: 0,
+    tokenStorePath: path.join(os.tmpdir(), `openclaw-operator-summary-${Date.now()}-${Math.random().toString(36).slice(2)}.json`),
+    loadSeedData: false,
+    simulateBridges: false,
+    ...overrides,
+  };
+}
+
+async function start(
+  config: GatewayConfig,
+  state: StateManager = new StateManager(),
+): Promise<{ server: GatewayServer; baseUrl: string; token: string; state: StateManager }> {
+  const server = createGatewayServer(config, state);
+  servers.push(server);
+  await server.start();
+  const address = server.httpServer.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected TCP server address');
+  }
+  const token = server.tokenManager.getDefaultDevToken();
+  if (!token) {
+    throw new Error('Expected default dev token');
+  }
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    token,
+    state,
+  };
+}
+
+function approvalRequest(agentId: string, agentName: string): ApprovalRequest {
+  const createdAt = new Date(Date.now() - 2 * 60_000).toISOString();
+  return {
+    id: 'approval-1',
+    agent_id: agentId,
+    agent_name: agentName,
+    action_type: 'deploy',
+    title: 'Approve production deploy',
+    description: 'Ship the hotfix',
+    command: 'deploy --env production',
+    context: {
+      service: 'openclaw-console',
+      environment: 'production',
+      repository: 'IgorGanapolsky/openclaw-console',
+      risk_level: 'critical',
+    },
+    created_at: createdAt,
+    expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+  };
+}
+
+function bridgeSession(agentId: string): BridgeSession {
+  return {
+    id: 'bridge-1',
+    agent_id: agentId,
+    type: 'codex',
+    title: 'Codex Session',
+    cwd: '/workspace/openclaw-console',
+    closed: false,
+    created_at: new Date(Date.now() - 30 * 60_000).toISOString(),
+    updated_at: new Date(Date.now() - 20 * 60_000).toISOString(),
+    metadata: {},
+  };
+}
+
+async function seedSummaryState(state: StateManager): Promise<{ approvalId: string }> {
+  await state.upsertAgent({
+    id: 'agent-1',
+    name: 'Gateway Agent',
+    description: 'Handles releases',
+    status: 'busy',
+    workspace: '/workspace/openclaw-console',
+    tags: ['release'],
+    last_active: new Date(Date.now() - 5 * 60_000).toISOString(),
+    active_tasks: 0,
+    pending_approvals: 0,
+    git_state: {
+      repository_url: 'https://github.com/IgorGanapolsky/openclaw-console',
+      current_branch: 'develop',
+      current_commit: '6397ccd',
+      uncommitted_changes: 2,
+      ahead_by: 1,
+      behind_by: 0,
+      last_sync: new Date().toISOString(),
+    },
+  });
+
+  await state.upsertAgent({
+    id: 'agent-2',
+    name: 'Offline Agent',
+    description: 'Needs attention',
+    status: 'offline',
+    workspace: '/workspace/other',
+    tags: ['stale'],
+    last_active: new Date(Date.now() - 30 * 60_000).toISOString(),
+    active_tasks: 0,
+    pending_approvals: 0,
+  });
+
+  const runningTask = await state.createTask({
+    agent_id: 'agent-1',
+    title: 'Release candidate',
+    description: 'Build and validate artifacts',
+  });
+  await state.updateTaskStatus(runningTask.id, 'running');
+  await state.addTaskStep({
+    task_id: runningTask.id,
+    type: 'info',
+    content: 'Artifacts staged for review',
+  });
+
+  const failedTask = await state.createTask({
+    agent_id: 'agent-2',
+    title: 'Broken sync',
+    description: 'Sync failed',
+  });
+  await state.updateTaskStatus(failedTask.id, 'failed');
+  await state.addTaskStep({
+    task_id: failedTask.id,
+    type: 'error',
+    content: 'Git fetch failed on stale credentials',
+  });
+
+  await state.createIncident({
+    agent_id: 'agent-2',
+    agent_name: 'Offline Agent',
+    severity: 'critical',
+    title: 'Distribution stalled',
+    description: 'TestFlight upload blocked',
+  });
+
+  const pendingApproval = approvalRequest('agent-1', 'Gateway Agent');
+  void state.queueApproval(pendingApproval, 60 * 60 * 1000);
+  await state.upsertBridgeSession(bridgeSession('agent-1'));
+  return { approvalId: pendingApproval.id };
+}
+
+describe('dashboard operator summary API', () => {
+  test('returns a compact, authenticated operator summary', async () => {
+    const config = tempConfig({ approvalPolicyPreset: 'manual' as ApprovalPolicyPreset });
+    const state = new StateManager();
+    const seeded = await seedSummaryState(state);
+    const { baseUrl, token } = await start(config, state);
+
+    const response = await fetch(`${baseUrl}/api/dashboard/summary?limit=3`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as OperatorSummaryResponse;
+
+    expect(body.headline).toContain('critical incident');
+    expect(body.counts.incidents_critical).toBe(1);
+    expect(body.counts.approvals_pending).toBe(1);
+    expect(body.counts.tasks_failed).toBe(1);
+    expect(body.counts.bridges_stale).toBe(1);
+    expect(body.summary_lines).toContain('1 critical incident open');
+    expect(body.needs_attention).toContain('1 pending approval');
+    expect(body.tasks[0]?.status).toBe('failed');
+    expect(body.incidents[0]?.severity).toBe('critical');
+    expect(body.approvals[0]?.risk_level).toBe('critical');
+    expect(body.bridges[0]?.stale).toBe(true);
+    expect(body.agents[0]?.name).toBe('Offline Agent');
+
+    state.respondToApproval({
+      approval_id: seeded.approvalId,
+      decision: 'approved',
+      biometric_verified: true,
+      responded_at: new Date().toISOString(),
+    });
+
+    fs.rmSync(config.tokenStorePath, { force: true });
+  });
+
+  test('requires auth for operator summary', async () => {
+    const config = tempConfig();
+    const { baseUrl } = await start(config);
+
+    const response = await fetch(`${baseUrl}/api/dashboard/summary`);
+
+    expect(response.status).toBe(401);
+    fs.rmSync(config.tokenStorePath, { force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add an authenticated  gateway endpoint with compact counts, headline, attention items, and top operators lists
- add typed protocol contracts for the operator summary response
- cover the endpoint with focused gateway tests

## Verification
- npm test -- --runInBand tests/operator-summary.test.ts tests/runtime-config.test.ts
- npm run build
- pre-push hook: full openclaw-skills test suite + Android debug/unit verification
