### PR TITLE
fix: add Android CLI bootstrap check

### DIFF
--- a/.agents/skills/android-agent-workflow/SKILL.md
+++ b/.agents/skills/android-agent-workflow/SKILL.md
@@ -9,13 +9,15 @@ Make Android agent work fast, current, and quiet. Agents should use official And
 ## Required Workflow
 
 1. Inspect the narrow Android surface touched by the task.
-2. Prefer official Android CLI commands when available:
+2. Run the Android CLI preflight:
+   - `python3 scripts/check_android_cli.py`
+   - If it reports Android CLI is unavailable, keep working with the repo Gradle/SDK commands and state that fallback explicitly.
+3. Prefer official Android CLI commands when available:
    - `android sdk` for SDK/component setup.
    - `android emulator` for virtual device creation and lifecycle.
    - `android run` for deploy/run loops.
    - `android docs` for current Android, Firebase, Google, and Kotlin guidance.
    - `android skills` for official Android task instructions.
-3. If Android CLI is unavailable, use existing repo commands and state that the CLI path was unavailable.
 4. Keep summaries concise: report the changed files, the failing/passing command, and the next concrete fix. Do not paste full Gradle logs unless the exact failing lines are needed.
 5. Preserve iOS parity before changing Android UI or branding. Android should match the iOS/TestFlight visual source of truth unless the task explicitly says otherwise.
 
@@ -24,6 +26,7 @@ Make Android agent work fast, current, and quiet. Agents should use official And
 Run the narrowest applicable checks before reporting completion:
 
 ```bash
+python3 scripts/check_android_cli.py
 python3 scripts/sync_app_icons.py --check
 ./scripts/check-brand-parity.sh
 cd android && ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:lintDebug --no-daemon

--- a/.github/instructions/android.instructions.md
+++ b/.github/instructions/android.instructions.md
@@ -5,6 +5,7 @@
 - Prefer official Android CLI surfaces when available: `android sdk`, `android emulator`, `android run`, `android docs`, and `android skills`.
 - Use `android docs` for current Android, Firebase, Google, and Kotlin guidance before changing platform-sensitive APIs.
 - Use `android skills` for official workflow instructions such as Navigation, edge-to-edge, AGP migration, XML-to-Compose migration, and R8 analysis.
+- Run `python3 scripts/check_android_cli.py` before Android work. If Android CLI is unavailable, use repo Gradle/SDK commands and state that fallback in the final response.
 - Do not paste full Gradle logs in agent responses. Summarize the exact failing task, the relevant error lines, and the next fix.
 
 ## Architecture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify Android CLI bootstrap path
+        run: python3 scripts/check_android_cli.py --allow-missing-tools
+
       - name: Verify Android agent workflow guardrails
         run: python3 scripts/check_android_agent_guardrails.py
 

--- a/docs/openclaw-setup.md
+++ b/docs/openclaw-setup.md
@@ -2,6 +2,38 @@
 
 This guide covers installing the OpenClaw Work Console skills on your existing OpenClaw instance.
 
+## Android Agent CLI Preflight
+
+Android CLI is a preview tool for agentic Android work. OpenClaw agents should prefer it when it is installed, but Android development must still work through the repo Gradle and Android SDK path when it is unavailable.
+
+Use this preflight before Android changes:
+
+```bash
+python3 scripts/check_android_cli.py
+```
+
+Expected local fallback output on systems without the preview CLI:
+
+```text
+Android CLI: unavailable on PATH
+SDK fallback tools: available (sdkmanager, avdmanager, adb)
+Result: passed with SDK fallback tools.
+```
+
+After installing Android CLI from the official Android docs, run:
+
+```bash
+android init
+```
+
+That installs official Android agent skills. Until then, agents should use the existing repo checks:
+
+```bash
+python3 scripts/sync_app_icons.py --check
+./scripts/check-brand-parity.sh
+cd android && ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:lintDebug --no-daemon
+```
+
 ## Prerequisites
 
 - An OpenClaw instance running on a server you control (VPS, home lab, etc.)

--- a/scripts/check_android_agent_guardrails.py
+++ b/scripts/check_android_agent_guardrails.py
@@ -11,6 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 REQUIRED_SNIPPETS: dict[str, tuple[str, ...]] = {
     ".agents/skills/android-agent-workflow/SKILL.md": (
+        "python3 scripts/check_android_cli.py",
         "android sdk",
         "android emulator",
         "android run",
@@ -24,6 +25,7 @@ REQUIRED_SNIPPETS: dict[str, tuple[str, ...]] = {
     ),
     ".github/instructions/android.instructions.md": (
         "Android CLI",
+        "check_android_cli.py",
         "android docs",
         "android skills",
         "scripts/sync_app_icons.py --check",
@@ -48,12 +50,21 @@ REQUIRED_SNIPPETS: dict[str, tuple[str, ...]] = {
     ),
     ".github/workflows/ci.yml": (
         "Android Agent Guardrails",
+        "python3 scripts/check_android_cli.py --allow-missing-tools",
         "python3 scripts/check_android_agent_guardrails.py",
     ),
+    "scripts/check_android_cli.py": (
+        "Android CLI: unavailable on PATH",
+        "--allow-missing-tools",
+        "--require-android-cli",
+        "android init",
+    ),
     "scripts/pre-commit": (
+        "check_android_cli.py",
         "check_android_agent_guardrails.py",
     ),
     "scripts/pre-push": (
+        "check_android_cli.py",
         "check_android_agent_guardrails.py",
     ),
 }

--- a/scripts/check_android_cli.py
+++ b/scripts/check_android_cli.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Preflight Android CLI availability without dumping noisy SDK output."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+FALLBACK_TOOLS = ("sdkmanager", "avdmanager", "adb")
+
+
+@dataclass(frozen=True)
+class ToolStatus:
+    name: str
+    path: str | None
+
+    @property
+    def available(self) -> bool:
+        return self.path is not None
+
+
+def tool_status(name: str) -> ToolStatus:
+    return ToolStatus(name=name, path=shutil.which(name))
+
+
+def android_version() -> str:
+    try:
+        result = subprocess.run(
+            ["android", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"version unavailable: {exc}"
+
+    output = "\n".join(
+        line.strip()
+        for line in (result.stdout + "\n" + result.stderr).splitlines()
+        if line.strip()
+    )
+    if result.returncode == 0 and output:
+        return output.splitlines()[0]
+    if output:
+        return f"version command exited {result.returncode}: {output.splitlines()[0]}"
+    return f"version command exited {result.returncode} with no output"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check whether Android CLI or SDK fallback tools are available."
+    )
+    parser.add_argument(
+        "--require-android-cli",
+        action="store_true",
+        help="Fail unless the preview Android CLI `android` command is on PATH.",
+    )
+    parser.add_argument(
+        "--allow-missing-tools",
+        action="store_true",
+        help="Pass when neither Android CLI nor SDK tools are installed, for lightweight CI guardrail jobs.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    android = tool_status("android")
+    fallbacks = [tool_status(name) for name in FALLBACK_TOOLS]
+    fallback_names = [tool.name for tool in fallbacks if tool.available]
+
+    if android.available:
+        print(f"Android CLI: available at {android.path}")
+        print(f"Android CLI version: {android_version()}")
+        return 0
+
+    print("Android CLI: unavailable on PATH")
+    if fallback_names:
+        print(f"SDK fallback tools: available ({', '.join(fallback_names)})")
+    else:
+        print("SDK fallback tools: unavailable")
+
+    print(
+        "Guidance: use repo Gradle/SDK commands now; after installing the preview "
+        "Android CLI from official docs, run `android init` to install Android skills."
+    )
+
+    if args.require_android_cli:
+        print("Result: failed because --require-android-cli was set.")
+        return 1
+    if fallback_names:
+        print("Result: passed with SDK fallback tools.")
+        return 0
+    if args.allow_missing_tools:
+        print("Result: passed because --allow-missing-tools was set.")
+        return 0
+
+    print("Result: failed because neither Android CLI nor SDK fallback tools were found.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -29,7 +29,7 @@ STAGED_KT=$(git diff --cached --name-only --diff-filter=ACM | grep '\.kt$' || tr
 STAGED_SWIFT=$(git diff --cached --name-only --diff-filter=ACM | grep '\.swift$' || true)
 STAGED_TS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|js)$' || true)
 STAGED_ALL=$(git diff --cached --name-only --diff-filter=ACM || true)
-STAGED_ANDROID_GUARDRAILS=$(printf '%s\n' "$STAGED_ALL" | grep -E '(^\.agents/skills/android-agent-workflow/SKILL\.md$|^\.github/instructions/android\.instructions\.md$|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^\.github/workflows/(ci|pr-state-machine)\.yml$|^scripts/check_android_agent_guardrails\.py$|^scripts/pre-commit$|^scripts/pre-push$)' || true)
+STAGED_ANDROID_GUARDRAILS=$(printf '%s\n' "$STAGED_ALL" | grep -E '(^\.agents/skills/android-agent-workflow/SKILL\.md$|^\.github/instructions/android\.instructions\.md$|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^\.github/workflows/(ci|pr-state-machine)\.yml$|^scripts/check_android_(agent_guardrails|cli)\.py$|^scripts/pre-commit$|^scripts/pre-push$)' || true)
 STAGED_RELEASE_CONTRACT=$(printf '%s\n' "$STAGED_ALL" | grep -E '(^|/)(AppIcon\.appiconset/|mipmap-(anydpi-v26|mdpi|hdpi|xhdpi|xxhdpi|xxxhdpi)/|values/ic_launcher_background\.xml$|android/fastlane/metadata/|ios/OpenClawConsole/fastlane/metadata/|PRIVACY_POLICY\.md$|scripts/sync_app_icons\.py$|scripts/validate_release_contract\.py$|scripts/preflight-release\.sh$|\.github/workflows/(ci|store-listing-parity|native-release|internal-distribution)\.yml$)' || true)
 
 if [ -n "$STAGED_ALL" ] && echo "$STAGED_ALL" | grep -qE '^(android/|ios/OpenClawConsole/OpenClawConsole/Assets\.xcassets/AppIcon\.appiconset/|scripts/check-brand-parity\.sh|scripts/sync-android-launcher-icon\.sh|scripts/android-launcher-icon\.manifest)'; then
@@ -39,6 +39,10 @@ if [ -n "$STAGED_ALL" ] && echo "$STAGED_ALL" | grep -qE '^(android/|ios/OpenCla
 fi
 
 if [ -n "$STAGED_ANDROID_GUARDRAILS" ]; then
+  if ! python3 scripts/check_android_cli.py; then
+    err "Android CLI preflight failed"
+  fi
+
   if ! python3 scripts/check_android_agent_guardrails.py; then
     err "Android agent guardrail validation failed"
   fi

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -9,6 +9,7 @@ echo "==> Checking release contract"
 python3 scripts/validate_release_contract.py --platform both
 
 echo "==> Checking Android agent guardrails"
+python3 scripts/check_android_cli.py
 python3 scripts/check_android_agent_guardrails.py
 
 echo "==> Android unit tests + debug build"


### PR DESCRIPTION
## Summary
- add a concise Android CLI preflight that falls back to installed SDK tools
- wire the check into Android agent guardrails, CI, pre-commit, and pre-push
- document the local fallback path and android init handoff

## Verification
- python3 scripts/check_android_cli.py
- python3 scripts/check_android_agent_guardrails.py
- python3 -m py_compile scripts/check_android_cli.py scripts/check_android_agent_guardrails.py
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "YAML OK #{f}" }' .github/workflows/ci.yml
- git diff --check
- scripts/pre-commit
- git push pre-push hook: Android Gradle build + skills tests