### PR TITLE
fix: add Android skill frontmatter

### DIFF
--- a/.agents/skills/android-agent-workflow/SKILL.md
+++ b/.agents/skills/android-agent-workflow/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: android-agent-workflow
+description: Use when modifying Android code, launcher icons, Firebase App Distribution, Compose UI, Gradle, Android CI, Android release metadata, or Android agent workflow guardrails in OpenClaw Console.
+---
+
 # Android Agent Workflow
 
 Use this skill when an agent modifies `android/`, Android launcher icons, Firebase App Distribution, Compose UI, Gradle, Android CI, or Android release metadata.

--- a/scripts/check_android_agent_guardrails.py
+++ b/scripts/check_android_agent_guardrails.py
@@ -8,9 +8,13 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+ANDROID_SKILL_PATH = ".agents/skills/android-agent-workflow/SKILL.md"
 
 REQUIRED_SNIPPETS: dict[str, tuple[str, ...]] = {
-    ".agents/skills/android-agent-workflow/SKILL.md": (
+    ANDROID_SKILL_PATH: (
+        "---",
+        "name: android-agent-workflow",
+        "description:",
         "python3 scripts/check_android_cli.py",
         "android sdk",
         "android emulator",
@@ -83,6 +87,21 @@ def main() -> int:
         for snippet in snippets:
             if snippet not in text:
                 failures.append(f"{relative_path}: missing `{snippet}`")
+
+    skill_path = ROOT / ANDROID_SKILL_PATH
+    if skill_path.exists():
+        text = skill_path.read_text(encoding="utf-8")
+        if not text.startswith("---\n"):
+            failures.append(f"{ANDROID_SKILL_PATH}: missing YAML frontmatter opener")
+        else:
+            frontmatter_end = text.find("\n---\n", 4)
+            if frontmatter_end == -1:
+                failures.append(f"{ANDROID_SKILL_PATH}: missing YAML frontmatter closer")
+            else:
+                frontmatter = text[4:frontmatter_end]
+                for field in ("name:", "description:"):
+                    if field not in frontmatter:
+                        failures.append(f"{ANDROID_SKILL_PATH}: frontmatter missing `{field}`")
 
     if failures:
         print("Android agent guardrails are incomplete:")


### PR DESCRIPTION
## Summary
- add required YAML frontmatter to the Android agent workflow skill
- update Android guardrail validation to catch missing skill frontmatter

## Verification
- python3 scripts/check_android_agent_guardrails.py
- python3 scripts/check_android_cli.py
- direct YAML frontmatter parse
- scripts/pre-commit
- git push pre-push hook: release contract, Android debug build/tests, skills tests