### PR TITLE
fix: target internal distribution to testers

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -50,10 +50,12 @@ jobs:
             if [[ " $ALLOWED_BRANCHES " != *" $WORKFLOW_BRANCH "* ]]; then
               REASON="branch_not_eligible_${WORKFLOW_BRANCH}"
               echo "gate: skipping internal distribution for branch=$WORKFLOW_BRANCH"
-              echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
-              echo "ref=$REF" >> "$GITHUB_OUTPUT"
-              echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-              echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+              {
+                echo "should_run=$SHOULD_RUN"
+                echo "ref=$REF"
+                echo "sha=$SHA"
+                echo "reason=$REASON"
+              } >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
@@ -63,10 +65,12 @@ jobs:
             REASON="ci_green_on_${WORKFLOW_BRANCH}"
           fi
 
-          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+          {
+            echo "should_run=$SHOULD_RUN"
+            echo "ref=$REF"
+            echo "sha=$SHA"
+            echo "reason=$REASON"
+          } >> "$GITHUB_OUTPUT"
           echo "gate: should_run=$SHOULD_RUN reason=$REASON ref=$REF sha=$SHA"
 
   ios-testflight-internal:
@@ -178,9 +182,9 @@ jobs:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || secrets.TESTFLIGHT_GROUPS || 'Internal Testers' }}
-          TESTFLIGHT_DISTRIBUTE_EXTERNAL: "false"
-          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "false"
+          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || vars.TESTFLIGHT_GROUPS || secrets.TESTFLIGHT_GROUPS || 'App Store Connect Users' }}
+          TESTFLIGHT_DISTRIBUTE_EXTERNAL: ${{ vars.TESTFLIGHT_DISTRIBUTE_EXTERNAL || 'false' }}
+          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: ${{ vars.TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS || 'false' }}
           TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING: "true"
           TESTFLIGHT_ARCHIVE_ONLY: "true"
         run: |
@@ -202,9 +206,9 @@ jobs:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || secrets.TESTFLIGHT_GROUPS || 'Internal Testers' }}
-          TESTFLIGHT_DISTRIBUTE_EXTERNAL: "false"
-          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "false"
+          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || vars.TESTFLIGHT_GROUPS || secrets.TESTFLIGHT_GROUPS || 'App Store Connect Users' }}
+          TESTFLIGHT_DISTRIBUTE_EXTERNAL: ${{ vars.TESTFLIGHT_DISTRIBUTE_EXTERNAL || 'false' }}
+          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: ${{ vars.TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS || 'false' }}
           TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING: "true"
           TESTFLIGHT_UPLOAD_ONLY: "true"
         run: |

--- a/ios/OpenClawConsole/fastlane/Fastfile
+++ b/ios/OpenClawConsole/fastlane/Fastfile
@@ -267,6 +267,7 @@ platform :ios do
       skip_waiting_for_build_processing: truthy_env?("TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING", default: true),
       api_key: api_key,
       ipa: configured_ipa_path,
+      groups: [configured_testflight_group],
       beta_app_description: ENV["TESTFLIGHT_BETA_DESCRIPTION"] || "OpenClaw Console beta build for external testing.",
       beta_app_feedback_email: ENV["TESTFLIGHT_FEEDBACK_EMAIL"] || "igor.ganapolsky@icloud.com",
       changelog: "Latest OpenClaw Console beta build"
@@ -280,14 +281,16 @@ platform :ios do
       upload_options[:beta_app_review_info] = beta_review_info
       upload_options[:distribute_external] = true
       upload_options[:notify_external_testers] = notify_external_testers
-      upload_options[:groups] = [configured_testflight_group]
     elsif distribute_external
       UI.important(
         "Missing TESTFLIGHT_CONTACT_* metadata. Uploading to internal/private TestFlight only; " \
         "external distribution is disabled for this run."
       )
     else
-      UI.message("TESTFLIGHT_DISTRIBUTE_EXTERNAL=false; uploading internal/private TestFlight build only.")
+      UI.message(
+        "TESTFLIGHT_DISTRIBUTE_EXTERNAL=false; assigning internal/private TestFlight build to " \
+        "#{configured_testflight_group.inspect}."
+      )
     end
 
     upload_to_testflight(**upload_options)


### PR DESCRIPTION
## Summary
- Use repo TESTFLIGHT_GROUPS variables when selecting the TestFlight group for internal distribution.
- Pass the configured TestFlight group into upload_to_testflight for internal/private uploads so processed builds are tester-targeted instead of only binary uploads.
- Clean up internal-distribution workflow shell output writes for actionlint.

## Evidence
- actionlint .github/workflows/internal-distribution.yml
- ruby -c ios/OpenClawConsole/fastlane/Fastfile
- python3 scripts/sync_app_icons.py --check
- bash scripts/check-brand-parity.sh
- python3 scripts/validate_release_contract.py --platform android
- python3 scripts/validate_release_contract.py --platform ios
- ./scripts/pre-commit
- cd openclaw-skills && npm test -- --runInBand
- pre-push hook: release contract, Android unit tests + debug build, skills tests