### PR TITLE
Fix TestFlight internal visibility read-back

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Install Pillow
         run: python3 -m pip install pillow
 
+      - name: Install App Store Connect Python dependencies
+        run: python3 -m pip install pyjwt==2.11.0 cryptography==46.0.5
+
       - name: Fail fast on required iOS distribution secrets
         env:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
@@ -215,6 +218,28 @@ jobs:
           set -Eeuo pipefail
           bundle exec fastlane beta --verbose 2>&1 | tee fastlane-upload.log
         working-directory: ios/OpenClawConsole
+
+      - name: Ensure TestFlight internal visibility
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY_PATH: ${{ env.APPSTORE_KEY_PATH }}
+          TESTFLIGHT_INTERNAL_GROUPS: ${{ vars.TESTFLIGHT_INTERNAL_GROUPS || vars.TESTFLIGHT_GROUPS || secrets.TESTFLIGHT_GROUPS || 'App Store Connect Users' }}
+          TESTFLIGHT_REQUIRED_TESTERS: ${{ vars.TESTFLIGHT_INTERNAL_TESTERS || secrets.TESTFLIGHT_INTERNAL_TESTERS || '' }}
+        run: |
+          set -euo pipefail
+          VERSION="$(cd ios/OpenClawConsole && xcodebuild -showBuildSettings -scheme OpenClawConsole 2>/dev/null | awk -F'= ' '/MARKETING_VERSION/ {print $2; exit}')"
+          if [ -z "$VERSION" ]; then
+            echo "❌ Could not resolve iOS MARKETING_VERSION"
+            exit 1
+          fi
+          python3 scripts/ensure_testflight_visibility.py \
+            --version "$VERSION" \
+            --groups "$TESTFLIGHT_INTERNAL_GROUPS" \
+            --required-testers "$TESTFLIGHT_REQUIRED_TESTERS" \
+            --wait \
+            --timeout 900 \
+            --poll-interval 60
 
       - name: Collect iOS distribution logs
         if: always()

--- a/ios/OpenClawConsole/fastlane/Fastfile
+++ b/ios/OpenClawConsole/fastlane/Fastfile
@@ -4,7 +4,7 @@ require "shellwords"
 default_platform(:ios)
 
 APP_IDENTIFIER = "com.openclaw.console"
-DEFAULT_TESTFLIGHT_GROUP = "External Testers"
+DEFAULT_TESTFLIGHT_GROUP = "Internal Testers"
 DEFAULT_EXTERNAL_TESTERS = [
   { email: "iganapolsky@gmail.com", first_name: "Igor", last_name: "Ganapolsky" },
   { email: "igor.ganapolsky@icloud.com", first_name: "Igor", last_name: "Ganapolsky" }
@@ -263,21 +263,22 @@ platform :ios do
       UI.message("Skipping automated tester sync. Set TESTFLIGHT_SYNC_TESTERS=true to enable it.")
     end
 
+    distribute_external = truthy_env?("TESTFLIGHT_DISTRIBUTE_EXTERNAL", default: false)
+    notify_external_testers = truthy_env?("TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS", default: distribute_external)
+
     upload_options = {
-      skip_waiting_for_build_processing: truthy_env?("TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING", default: true),
+      skip_waiting_for_build_processing: truthy_env?("TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING", default: false),
       api_key: api_key,
       ipa: configured_ipa_path,
-      groups: [configured_testflight_group],
-      beta_app_description: ENV["TESTFLIGHT_BETA_DESCRIPTION"] || "OpenClaw Console beta build for external testing.",
+      beta_app_description: ENV["TESTFLIGHT_BETA_DESCRIPTION"] || "OpenClaw Console beta build for internal testing.",
       beta_app_feedback_email: ENV["TESTFLIGHT_FEEDBACK_EMAIL"] || "igor.ganapolsky@icloud.com",
       changelog: "Latest OpenClaw Console beta build"
     }
 
     beta_review_info = beta_review_info_from_env
-    distribute_external = truthy_env?("TESTFLIGHT_DISTRIBUTE_EXTERNAL", default: true)
-    notify_external_testers = truthy_env?("TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS", default: distribute_external)
 
     if distribute_external && beta_review_info
+      upload_options[:groups] = [configured_testflight_group]
       upload_options[:beta_app_review_info] = beta_review_info
       upload_options[:distribute_external] = true
       upload_options[:notify_external_testers] = notify_external_testers
@@ -288,8 +289,8 @@ platform :ios do
       )
     else
       UI.message(
-        "TESTFLIGHT_DISTRIBUTE_EXTERNAL=false; assigning internal/private TestFlight build to " \
-        "#{configured_testflight_group.inspect}."
+        "TESTFLIGHT_DISTRIBUTE_EXTERNAL=false; uploading as internal/private TestFlight build. " \
+        "Post-upload ASC visibility checks own group/tester verification."
       )
     end
 

--- a/scripts/ensure_testflight_visibility.py
+++ b/scripts/ensure_testflight_visibility.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Verify an OpenClaw TestFlight build is processed and visible to internal testers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+APP_STORE_CONNECT_API = "https://api.appstoreconnect.apple.com/v1"
+IOS_BUNDLE_ID = "com.openclaw.console"
+
+
+def csv(raw: str) -> list[str]:
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def private_key_from_env() -> str:
+    raw = (os.environ.get("APPSTORE_PRIVATE_KEY") or "").strip()
+    if raw and "-----BEGIN" in raw:
+        return raw
+
+    path = (
+        os.environ.get("APPSTORE_PRIVATE_KEY_PATH")
+        or os.environ.get("APPSTORE_KEY_PATH")
+        or ""
+    ).strip()
+    if not path and os.environ.get("APPSTORE_KEY_ID"):
+        path = f"~/.appstoreconnect/private_keys/AuthKey_{os.environ['APPSTORE_KEY_ID']}.p8"
+
+    expanded = Path(path).expanduser() if path else None
+    if expanded and expanded.is_file():
+        return expanded.read_text(encoding="utf-8")
+
+    if raw:
+        return raw
+
+    raise RuntimeError("Missing APPSTORE_PRIVATE_KEY or APPSTORE_PRIVATE_KEY_PATH")
+
+
+def asc_token() -> str:
+    try:
+        import jwt
+    except ImportError as exc:
+        raise RuntimeError("Missing PyJWT. Install pyjwt and cryptography.") from exc
+
+    key_id = os.environ.get("APPSTORE_KEY_ID", "").strip()
+    issuer_id = os.environ.get("APPSTORE_ISSUER_ID", "").strip()
+    if not key_id or not issuer_id:
+        raise RuntimeError("Missing APPSTORE_KEY_ID or APPSTORE_ISSUER_ID")
+
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": issuer_id,
+            "iat": now,
+            "exp": now + 20 * 60,
+            "aud": "appstoreconnect-v1",
+        },
+        private_key_from_env(),
+        algorithm="ES256",
+        headers={"kid": key_id, "typ": "JWT"},
+    )
+
+
+class ASCClient:
+    def __init__(self) -> None:
+        self.token = asc_token()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        query = f"?{urlencode(params)}" if params else ""
+        data = json.dumps(payload).encode("utf-8") if payload is not None else None
+        req = Request(
+            f"{APP_STORE_CONNECT_API}{path}{query}",
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            },
+        )
+        with urlopen(req, timeout=30) as response:
+            body = response.read().decode("utf-8")
+            return json.loads(body) if body else {}
+
+    def get_all(self, path: str, *, params: dict[str, str] | None = None) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        next_url: str | None = None
+        while True:
+            if next_url:
+                req = Request(next_url, headers={"Authorization": f"Bearer {self.token}"})
+                with urlopen(req, timeout=30) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+            else:
+                payload = self.request("GET", path, params=params)
+            items.extend(payload.get("data", []))
+            next_url = payload.get("links", {}).get("next")
+            if not next_url:
+                return items
+
+
+class TestFlightVisibility:
+    def __init__(self, client: ASCClient, bundle_id: str) -> None:
+        self.client = client
+        self.bundle_id = bundle_id
+
+    def app_id(self) -> str:
+        payload = self.client.request("GET", "/apps", params={"filter[bundleId]": self.bundle_id})
+        apps = payload.get("data", [])
+        if not apps:
+            raise RuntimeError(f"No App Store Connect app found for bundle id {self.bundle_id}")
+        return apps[0]["id"]
+
+    def latest_build(self, app_id: str, marketing_version: str) -> dict[str, Any]:
+        payload = self.client.request(
+            "GET",
+            "/builds",
+            params={
+                "filter[app]": app_id,
+                "include": "preReleaseVersion",
+                "sort": "-uploadedDate",
+                "limit": "50",
+                "fields[builds]": "version,processingState,uploadedDate,preReleaseVersion",
+                "fields[preReleaseVersions]": "version",
+            },
+        )
+        versions = {
+            item["id"]: item.get("attributes", {}).get("version")
+            for item in payload.get("included", [])
+            if item.get("type") == "preReleaseVersions"
+        }
+        for build in payload.get("data", []):
+            rel = build.get("relationships", {}).get("preReleaseVersion", {}).get("data")
+            rel_id = rel.get("id") if isinstance(rel, dict) else None
+            if versions.get(rel_id) == marketing_version:
+                return build
+        raise RuntimeError(f"No TestFlight build found for marketing version {marketing_version}")
+
+    def groups(self, app_id: str) -> dict[str, dict[str, Any]]:
+        groups = self.client.get_all(f"/apps/{app_id}/betaGroups", params={"limit": "200"})
+        return {group["attributes"]["name"]: group for group in groups}
+
+    def group_build_ids(self, group_id: str) -> set[str]:
+        builds = self.client.get_all(f"/betaGroups/{group_id}/builds", params={"limit": "200"})
+        return {build["id"] for build in builds}
+
+    def group_testers(self, group_id: str) -> set[str]:
+        testers = self.client.get_all(f"/betaGroups/{group_id}/betaTesters", params={"limit": "200"})
+        return {
+            (tester.get("attributes", {}).get("email") or "").strip().lower()
+            for tester in testers
+            if tester.get("attributes", {}).get("email")
+        }
+
+    def attach_external_group_build(self, group_id: str, build_id: str) -> None:
+        try:
+            self.client.request(
+                "POST",
+                f"/betaGroups/{group_id}/relationships/builds",
+                payload={"data": [{"type": "builds", "id": build_id}]},
+            )
+        except Exception as exc:
+            if "409" not in str(exc):
+                raise
+
+    def ensure(self, version: str, groups: list[str], required_testers: list[str]) -> dict[str, Any]:
+        app_id = self.app_id()
+        build = self.latest_build(app_id, version)
+        build_id = build["id"]
+        attrs = build.get("attributes", {})
+        build_number = str(attrs.get("version", "?"))
+        processing_state = attrs.get("processingState", "UNKNOWN")
+        if processing_state != "VALID":
+            raise RuntimeError(
+                f"Latest TestFlight build {version} ({build_number}) is not VALID; processingState={processing_state}"
+            )
+
+        app_groups = self.groups(app_id)
+        verified_groups: list[str] = []
+        missing_groups: list[str] = []
+        missing_testers: list[str] = []
+
+        for name in groups:
+            group = app_groups.get(name)
+            if not group:
+                missing_groups.append(name)
+                continue
+
+            group_id = group["id"]
+            attrs = group.get("attributes", {})
+            if not bool(attrs.get("isInternalGroup")):
+                self.attach_external_group_build(group_id, build_id)
+
+            if build_id not in self.group_build_ids(group_id):
+                raise RuntimeError(f"Build {version} ({build_number}) is missing from TestFlight group '{name}'")
+
+            testers = self.group_testers(group_id)
+            missing = [email for email in required_testers if email.lower() not in testers]
+            if missing:
+                missing_testers.append(f"{name}: {', '.join(missing)}")
+            verified_groups.append(name)
+
+        if missing_groups:
+            raise RuntimeError("Missing TestFlight groups: " + ", ".join(missing_groups))
+        if missing_testers:
+            raise RuntimeError("Required TestFlight testers missing from group membership: " + "; ".join(missing_testers))
+
+        return {
+            "status": "VISIBLE",
+            "version": version,
+            "build_number": build_number,
+            "processing_state": processing_state,
+            "groups": verified_groups,
+            "required_testers_checked": len(required_testers),
+        }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--bundle-id", default=IOS_BUNDLE_ID)
+    parser.add_argument("--groups", default="")
+    parser.add_argument("--required-testers", default="")
+    parser.add_argument("--wait", action="store_true")
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--poll-interval", type=int, default=60)
+    args = parser.parse_args()
+
+    deadline = time.monotonic() + args.timeout
+    last_error: Exception | None = None
+
+    while True:
+        try:
+            result = TestFlightVisibility(ASCClient(), args.bundle_id).ensure(
+                args.version,
+                csv(args.groups),
+                [email.lower() for email in csv(args.required_testers)],
+            )
+            print(json.dumps(result, sort_keys=True))
+            return 0
+        except Exception as exc:
+            last_error = exc
+            if not args.wait or time.monotonic() >= deadline:
+                break
+            print(f"Waiting for TestFlight visibility: {exc}", file=sys.stderr)
+            time.sleep(args.poll_interval)
+
+    print(f"TestFlight visibility check failed: {last_error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_release_contract.py
+++ b/scripts/validate_release_contract.py
@@ -16,6 +16,8 @@ ANDROID_METADATA = ROOT / "android/fastlane/metadata/android/en-US"
 IOS_METADATA = ROOT / "ios/OpenClawConsole/fastlane/metadata/en-US"
 ANDROID_GRADLE = ROOT / "android/app/build.gradle.kts"
 IOS_PBXPROJ = ROOT / "ios/OpenClawConsole/OpenClawConsole.xcodeproj/project.pbxproj"
+IOS_FASTFILE = ROOT / "ios/OpenClawConsole/fastlane/Fastfile"
+INTERNAL_DISTRIBUTION_WORKFLOW = ROOT / ".github/workflows/internal-distribution.yml"
 PRIVACY_POLICY = ROOT / "PRIVACY_POLICY.md"
 
 
@@ -250,6 +252,42 @@ def check_cross_platform_parity(result: ValidationResult) -> None:
         )
 
 
+def check_testflight_distribution_contract(result: ValidationResult) -> None:
+    if not IOS_FASTFILE.is_file():
+        result.error("Missing iOS Fastfile for TestFlight distribution checks.")
+        return
+    if not INTERNAL_DISTRIBUTION_WORKFLOW.is_file():
+        result.error("Missing internal distribution workflow.")
+        return
+
+    fastfile = IOS_FASTFILE.read_text(encoding="utf-8")
+    workflow = INTERNAL_DISTRIBUTION_WORKFLOW.read_text(encoding="utf-8")
+
+    for fragment in (
+        'truthy_env?("TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING", default: false)',
+        'truthy_env?("TESTFLIGHT_DISTRIBUTE_EXTERNAL", default: false)',
+        'upload_options[:groups] = [configured_testflight_group]',
+        "Post-upload ASC visibility checks own group/tester verification.",
+    ):
+        if fragment not in fastfile:
+            result.error(f"iOS Fastfile TestFlight contract missing: {fragment}")
+
+    if "upload_options = {" in fastfile and "if distribute_external" in fastfile:
+        internal_upload_block = fastfile.split("upload_options = {", 1)[1].split("if distribute_external", 1)[0]
+        if "groups:" in internal_upload_block or "upload_options[:groups]" in internal_upload_block:
+            result.error("iOS Fastfile must not assign TestFlight groups before external distribution is enabled.")
+
+    for fragment in (
+        "Install App Store Connect Python dependencies",
+        "Ensure TestFlight internal visibility",
+        "scripts/ensure_testflight_visibility.py",
+        "TESTFLIGHT_REQUIRED_TESTERS",
+        'TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING: "false"',
+    ):
+        if fragment not in workflow:
+            result.error(f"Internal distribution workflow missing TestFlight read-back contract: {fragment}")
+
+
 def render(result: ValidationResult) -> int:
     print("OpenClaw release contract")
     print(f"Repo: {ROOT}")
@@ -287,6 +325,7 @@ def main() -> int:
         check_android(result, args.strict_screenshots)
     if args.platform in {"ios", "both"}:
         check_ios(result, args.strict_screenshots)
+        check_testflight_distribution_contract(result)
     if args.platform == "both":
         check_cross_platform_parity(result)
 


### PR DESCRIPTION
## Summary
- Align OpenClaw TestFlight upload behavior with the proven Random-Timer internal-only pattern.
- Default Fastlane TestFlight uploads to wait for processing and avoid assigning groups unless external distribution is explicitly enabled.
- Add App Store Connect read-back that verifies the latest build is VALID, attached to configured internal TestFlight group(s), and includes required tester membership.
- Add release-contract checks so this cannot regress silently.

## Verification
- ruby -c ios/OpenClawConsole/fastlane/Fastfile
- python3 -m py_compile scripts/ensure_testflight_visibility.py scripts/validate_release_contract.py
- python3 scripts/validate_release_contract.py --platform both
- actionlint .github/workflows/internal-distribution.yml
- git diff --check
- ./scripts/pre-commit
- git push pre-push hook: Android build/tests passed; skills tests passed 12 suites / 106 tests; local iOS skipped due unresolved Swift packages, CI authoritative