### PR TITLE
fix: assign TestFlight testers to internal builds

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -237,6 +237,7 @@ jobs:
             --version "$VERSION" \
             --groups "$TESTFLIGHT_INTERNAL_GROUPS" \
             --required-testers "$TESTFLIGHT_REQUIRED_TESTERS" \
+            --assign-required-testers \
             --wait \
             --timeout 900 \
             --poll-interval 60

--- a/scripts/ensure_testflight_visibility.py
+++ b/scripts/ensure_testflight_visibility.py
@@ -175,17 +175,33 @@ class TestFlightVisibility:
             if tester.get("attributes", {}).get("email")
         }
 
-    def beta_tester_exists(self, email: str) -> bool:
+    def beta_tester(self, email: str) -> dict[str, Any] | None:
         payload = self.client.request(
             "GET",
             "/betaTesters",
             params={
                 "filter[email]": email,
-                "fields[betaTesters]": "email",
+                "fields[betaTesters]": "email,firstName,lastName,inviteType",
                 "limit": "1",
             },
         )
-        return bool(payload.get("data", []))
+        testers = payload.get("data", [])
+        return testers[0] if testers else None
+
+    def beta_tester_build_ids(self, tester_id: str) -> set[str]:
+        builds = self.client.get_all(f"/betaTesters/{tester_id}/relationships/builds", params={"limit": "200"})
+        return {build["id"] for build in builds}
+
+    def attach_beta_tester_build(self, tester_id: str, build_id: str) -> None:
+        try:
+            self.client.request(
+                "POST",
+                f"/betaTesters/{tester_id}/relationships/builds",
+                payload={"data": [{"type": "builds", "id": build_id}]},
+            )
+        except Exception as exc:
+            if "409" not in str(exc):
+                raise
 
     def attach_external_group_build(self, group_id: str, build_id: str) -> None:
         try:
@@ -198,7 +214,14 @@ class TestFlightVisibility:
             if "409" not in str(exc):
                 raise
 
-    def ensure(self, version: str, groups: list[str], required_testers: list[str]) -> dict[str, Any]:
+    def ensure(
+        self,
+        version: str,
+        groups: list[str],
+        required_testers: list[str],
+        *,
+        assign_required_testers: bool = False,
+    ) -> dict[str, Any]:
         app_id = self.app_id()
         build = self.latest_build(app_id, version)
         build_id = build["id"]
@@ -215,6 +238,7 @@ class TestFlightVisibility:
         verified_groups: list[str] = []
         missing_groups: list[str] = []
         missing_testers: list[str] = []
+        assigned_required_testers: list[str] = []
 
         for name in groups:
             if is_internal_pseudo_group(name):
@@ -244,11 +268,36 @@ class TestFlightVisibility:
             raise RuntimeError("Missing TestFlight groups: " + ", ".join(missing_groups))
 
         if groups and all(is_internal_pseudo_group(name) for name in groups):
-            missing = [email for email in required_testers if not self.beta_tester_exists(email.lower())]
+            missing: list[str] = []
+            missing_build_access: list[str] = []
+            for email in required_testers:
+                normalized_email = email.lower()
+                tester = self.beta_tester(normalized_email)
+                if not tester:
+                    missing.append(normalized_email)
+                    continue
+
+                tester_id = tester["id"]
+                if build_id in self.beta_tester_build_ids(tester_id):
+                    continue
+
+                if assign_required_testers:
+                    self.attach_beta_tester_build(tester_id, build_id)
+                    if build_id in self.beta_tester_build_ids(tester_id):
+                        assigned_required_testers.append(normalized_email)
+                        continue
+
+                missing_build_access.append(normalized_email)
+
             if missing:
                 raise RuntimeError(
                     "Required internal TestFlight testers missing from App Store Connect beta testers: "
                     + ", ".join(missing)
+                )
+            if missing_build_access:
+                raise RuntimeError(
+                    "Required internal TestFlight testers are not assigned to build "
+                    f"{version} ({build_number}): " + ", ".join(missing_build_access)
                 )
 
         if missing_testers:
@@ -261,6 +310,7 @@ class TestFlightVisibility:
             "processing_state": processing_state,
             "groups": verified_groups,
             "required_testers_checked": len(required_testers),
+            "required_testers_assigned": len(assigned_required_testers),
         }
 
 
@@ -270,6 +320,7 @@ def main() -> int:
     parser.add_argument("--bundle-id", default=IOS_BUNDLE_ID)
     parser.add_argument("--groups", default="")
     parser.add_argument("--required-testers", default="")
+    parser.add_argument("--assign-required-testers", action="store_true")
     parser.add_argument("--wait", action="store_true")
     parser.add_argument("--timeout", type=int, default=900)
     parser.add_argument("--poll-interval", type=int, default=60)
@@ -284,6 +335,7 @@ def main() -> int:
                 args.version,
                 csv(args.groups),
                 [email.lower() for email in csv(args.required_testers)],
+                assign_required_testers=args.assign_required_testers,
             )
             print(json.dumps(result, sort_keys=True))
             return 0

--- a/scripts/tests/test_ensure_testflight_visibility.py
+++ b/scripts/tests/test_ensure_testflight_visibility.py
@@ -8,9 +8,11 @@ from scripts.ensure_testflight_visibility import TestFlightVisibility, is_intern
 
 
 class FakeClient:
-    def __init__(self, *, tester_exists: bool = True) -> None:
+    def __init__(self, *, tester_exists: bool = True, tester_has_build: bool = True) -> None:
         self.tester_exists = tester_exists
+        self.tester_has_build = tester_has_build
         self.group_requests = 0
+        self.assigned_builds: list[tuple[str, str]] = []
 
     def request(self, method, path, *, params=None, payload=None):
         if path == "/apps":
@@ -27,13 +29,20 @@ class FakeClient:
                 "included": [{"type": "preReleaseVersions", "id": "pr-1", "attributes": {"version": "1.0.0"}}],
             }
         if path == "/betaTesters":
-            return {"data": [{"id": "tester-1"}] if self.tester_exists else []}
+            return {"data": [{"id": "tester-1", "attributes": {"email": "iganapolsky@gmail.com"}}] if self.tester_exists else []}
+        if path == "/betaTesters/tester-1/relationships/builds":
+            if method == "POST":
+                self.assigned_builds.append(("tester-1", payload["data"][0]["id"]))
+                self.tester_has_build = True
+                return {}
         raise AssertionError(f"unexpected request: {method} {path}")
 
     def get_all(self, path, *, params=None):
         if path == "/apps/app-1/betaGroups":
             self.group_requests += 1
             return []
+        if path == "/betaTesters/tester-1/relationships/builds":
+            return [{"id": "build-1"}] if self.tester_has_build else []
         raise AssertionError(f"unexpected get_all: {path}")
 
 
@@ -53,6 +62,8 @@ class TestInternalPseudoGroups(unittest.TestCase):
         self.assertEqual(result["status"], "VISIBLE")
         self.assertEqual(result["build_number"], "260504133807")
         self.assertEqual(result["groups"], ["App Store Connect Users"])
+        self.assertEqual(result["required_testers_checked"], 1)
+        self.assertEqual(result["required_testers_assigned"], 0)
         self.assertEqual(client.group_requests, 0)
 
     def test_pseudo_group_fails_when_required_tester_is_missing(self) -> None:
@@ -63,6 +74,27 @@ class TestInternalPseudoGroups(unittest.TestCase):
                 ["App Store Connect Users"],
                 ["iganapolsky@gmail.com"],
             )
+
+    def test_pseudo_group_fails_when_required_tester_lacks_build_access(self) -> None:
+        client = FakeClient(tester_exists=True, tester_has_build=False)
+        with self.assertRaisesRegex(RuntimeError, "not assigned to build"):
+            TestFlightVisibility(client, "com.openclaw.console").ensure(
+                "1.0.0",
+                ["App Store Connect Users"],
+                ["iganapolsky@gmail.com"],
+            )
+
+    def test_pseudo_group_assigns_required_tester_to_build_when_requested(self) -> None:
+        client = FakeClient(tester_exists=True, tester_has_build=False)
+        result = TestFlightVisibility(client, "com.openclaw.console").ensure(
+            "1.0.0",
+            ["App Store Connect Users"],
+            ["iganapolsky@gmail.com"],
+            assign_required_testers=True,
+        )
+        self.assertEqual(result["status"], "VISIBLE")
+        self.assertEqual(result["required_testers_assigned"], 1)
+        self.assertEqual(client.assigned_builds, [("tester-1", "build-1")])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- verify required TestFlight testers are assigned to the exact uploaded build, not merely present as beta testers
- allow the internal distribution workflow to assign missing required tester/build relationships
- expand coverage for missing tester access and auto-assignment

## Verification
- python3 -m unittest scripts.tests.test_ensure_testflight_visibility
- actionlint .github/workflows/internal-distribution.yml .github/workflows/ci.yml
- python3 scripts/validate_release_contract.py --platform ios
- python3 -m py_compile scripts/ensure_testflight_visibility.py scripts/tests/test_ensure_testflight_visibility.py
- ./scripts/pre-commit
- git push pre-push hook: Android unit tests + debug build, skills tests