### PR TITLE
ci: use stable macOS runner for TestFlight distribution

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 concurrency:
-  group: internal-distribution-${{ github.event_name }}-${{ github.event.workflow_run.head_branch || inputs.ref || github.ref_name }}
+  group: internal-distribution-${{ github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -77,7 +77,7 @@ jobs:
     name: iOS TestFlight (Internal)
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true'
-    runs-on: macos-26
+    runs-on: macos-15
     timeout-minutes: 45
     environment: production
     steps:


### PR DESCRIPTION
## Summary
- switch Internal Distribution TestFlight job from macos-26 to macos-15
- collapse workflow_dispatch and workflow_run concurrency into one branch-level group so duplicate distribution runs cancel each other

## Verification
- actionlint .github/workflows/internal-distribution.yml
- pre-push hook: release contract, Android debug build + unit tests, skills tests (106 passed)