### PR TITLE
ci: build TestFlight uploads with Xcode 26

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -77,7 +77,7 @@ jobs:
     name: iOS TestFlight (Internal)
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true'
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 45
     environment: production
     steps:


### PR DESCRIPTION
## Summary
- keep the branch-level Internal Distribution concurrency fix
- restore the TestFlight job to macos-26 because App Store Connect rejects iOS 18.5 SDK uploads and now requires iOS 26 SDK / Xcode 26

## Evidence
- Failed run 25327666554 on macos-15 produced build 260504152941 but App Store Connect rejected upload: built with iOS 18.5 SDK, requires iOS 26 SDK or later

## Verification
- actionlint .github/workflows/internal-distribution.yml
- pre-push hook: release contract, Android debug build + unit tests, skills tests (106 passed)