### PR TITLE
Add supply chain guardrails

### DIFF
--- a/docs/MARKETING_POSITIONING.md
+++ b/docs/MARKETING_POSITIONING.md
@@ -53,6 +53,7 @@ OpenClaw Console is positioned as the definitive mobile control plane for self-h
 | **Self-hosted** | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **Biometric approval** | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **Agent workflows** | ✅ | ❌ | ❌ | ❌ | ⚠️ |
+| **Supply-chain approval gates** | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **Privacy-first** | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **Price (per user)** | $15-20 | $21+ | $15-23 | $9-19 | $0-12.50 |
 | **Mobile-native** | ✅ | ✅ | ✅ | ✅ | ❌ |
@@ -78,6 +79,17 @@ OpenClaw Console is positioned as the definitive mobile control plane for self-h
 
 **Supporting Message (60+ seconds)**
 "Stop relying on Slack notifications and SSH sessions for critical operations. OpenClaw Console provides a professional mobile interface for approving database migrations, production deployments, and infrastructure changes with Face ID/Touch ID security. Self-hosted for complete data sovereignty, designed specifically for DevOps professionals who value security and privacy."
+
+### Supply-Chain Security Angle
+
+Developer machines are now part of the production attack surface because agents, package managers, dependency bots, and CLI tools can all touch non-human identities. OpenClaw turns those moments into explicit mobile decisions:
+
+- Approve or deny package installs, Docker runs, remote installer scripts, credential commands, and agent tooling changes.
+- Show sanitized secret exposure inventory by key name and source, never by value.
+- Open a rotation-first incident workflow when a developer-machine compromise is suspected.
+- Preserve the audit trail that proves who approved the action, when, and with what risk context.
+
+This is a sharper DAA driver than generic monitoring: every risky supply-chain action becomes a meaningful approval moment.
 
 ## Customer Personas
 

--- a/docs/MARKETING_POSITIONING.md
+++ b/docs/MARKETING_POSITIONING.md
@@ -91,6 +91,17 @@ Developer machines are now part of the production attack surface because agents,
 
 This is a sharper DAA driver than generic monitoring: every risky supply-chain action becomes a meaningful approval moment.
 
+### Agent Runtime Control Angle
+
+Cloud coding agents are moving into long-running, sandboxed background workflows. OpenClaw should be the mobile control plane around those systems:
+
+- Track background agent lifecycle separately from its sandbox: running, paused, hibernated, cancelled, failed, completed.
+- Give operators mobile controls for pause, resume, hibernate, cancel, and read-only session sharing.
+- Register modular skill workflow systems with explicit inputs, handoffs, checkpoints, and visual result artifacts.
+- Require approval for agent commerce actions such as Cloudflare account provisioning, paid subscriptions, domain registration, token minting, and production deploys.
+
+This keeps OpenClaw focused on DAA: every long-running agent needs observable state, cancellability, checkpoint approvals, and budget-aware infrastructure permissions.
+
 ## Customer Personas
 
 ### Primary Persona: Solo DevOps Engineer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,7 @@ The OpenClaw Work Console is a mobile-first monitoring and control system for Op
 - **Server-side intelligence, client-side display.** The mobile apps never call GitHub, trading APIs, or any external service directly. Everything goes through OpenClaw skills.
 - **Task-centric, not chat-centric.** The primary unit of work is a Task with a timeline of Steps, not a stream of chat messages.
 - **Secure by default.** Tokens in platform-secure storage, biometric-gated approvals, TLS enforced, VPN-friendly.
+- **Supply-chain aware.** Dependency installs, remote scripts, container image execution, credential commands, secret file access, and agent tooling changes are explicit approval events with credential-rotation context.
 - **Single-purpose.** No social features, no feeds, no media sharing. This is a work tool.
 
 ## System Diagram
@@ -172,3 +173,6 @@ These assumptions are documented here so they can be adjusted as OpenClaw's actu
 - Approval requests expire (configurable, default 5 minutes)
 - Full command/endpoint displayed to user before approval
 - All decisions are audit-logged server-side
+- Supply-chain guardrails classify risky commands and repo changes before policy auto-approval is evaluated
+- Sanitized secret inventory reports key names, file paths, GitHub Actions secret references, and package manifests without exposing values
+- Supply-chain incidents include containment, credential rotation, recovery, and evidence requirements

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -28,6 +28,9 @@ wss://gateway.example.com/ws?token=<gateway-token>
 | GET | `/api/incidents` | All incidents across agents |
 | GET | `/api/approvals/pending` | Pending approval requests |
 | POST | `/api/approvals/:id/respond` | Submit approval decision |
+| POST | `/api/security/supply-chain/assess` | Classify package, CLI, container, remote-script, and credential-command risk |
+| GET | `/api/security/secret-inventory` | Return sanitized secret-bearing key names and file names, never values |
+| POST | `/api/security/supply-chain/incidents` | Open a supply-chain incident with credential-rotation guidance |
 | POST | `/api/agents/:id/chat` | Send message to agent |
 
 ## WebSocket Events
@@ -138,12 +141,47 @@ wss://gateway.example.com/ws?token=<gateway-token>
     "service": "string",
     "environment": "string",
     "repository": "string",
-    "risk_level": "high" | "critical"
+    "risk_level": "high" | "critical",
+    "supply_chain": {
+      "detected": true,
+      "category": "dependency_install" | "container_image" | "remote_script" | "cli_install" | "credential_command" | "secret_touch" | "agent_tooling" | "mixed",
+      "severity": "high" | "critical",
+      "requires_explicit_approval": true,
+      "reasons": ["string"],
+      "recommended_questions": ["string"],
+      "recommended_rotations": ["string"]
+    }
   },
   "created_at": "ISO8601",
   "expires_at": "ISO8601"
 }
 ```
+
+### SecretExposureInventory
+```json
+{
+  "root_dir": "string",
+  "checked_at": "ISO8601",
+  "env_secret_key_names": ["GITHUB_TOKEN"],
+  "local_secret_files": [
+    {
+      "path": ".env",
+      "key_names": ["OPENAI_API_KEY"]
+    }
+  ],
+  "github_actions_secret_references": ["APPSTORE_KEY_ID"],
+  "package_manifests": ["package.json", "Dockerfile"],
+  "counts": {
+    "env_secret_keys": 1,
+    "local_secret_files": 1,
+    "local_secret_key_names": 1,
+    "github_actions_secret_references": 1,
+    "package_manifests": 2
+  }
+}
+```
+
+Secret inventory responses expose names and counts only. They MUST NOT include secret values.
 
 ### ApprovalResponse
 ```json
@@ -195,4 +233,6 @@ All WebSocket messages use this envelope:
 - Tokens MUST be stored in platform secure storage (Keychain / Android Keystore)
 - Tokens MUST NOT appear in logs
 - Approval responses MUST include biometric verification flag
+- Supply-chain risk approval requests MUST NOT be auto-approved by yolo presets
+- Secret inventory endpoints MUST return key names and source paths only, never values
 - Plain HTTP/WS connections require explicit user opt-in with warning

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -29,8 +29,12 @@ wss://gateway.example.com/ws?token=<gateway-token>
 | GET | `/api/approvals/pending` | Pending approval requests |
 | POST | `/api/approvals/:id/respond` | Submit approval decision |
 | POST | `/api/security/supply-chain/assess` | Classify package, CLI, container, remote-script, and credential-command risk |
+| POST | `/api/security/agent-commerce/assess` | Classify agent-created cloud accounts, paid services, domains, tokens, and deploys |
 | GET | `/api/security/secret-inventory` | Return sanitized secret-bearing key names and file names, never values |
 | POST | `/api/security/supply-chain/incidents` | Open a supply-chain incident with credential-rotation guidance |
+| GET | `/api/skill-workflows` | List reusable skill workflow systems, optionally filtered by `agent_id` |
+| POST | `/api/skill-workflows/upsert` | Register or update a modular skill workflow with handoffs, checkpoints, and artifacts |
+| POST | `/api/bridges/:id/control` | Pause, resume, hibernate, cancel, or attach a read-only share URL to a background agent session |
 | POST | `/api/agents/:id/chat` | Send message to agent |
 
 ## WebSocket Events
@@ -133,7 +137,7 @@ wss://gateway.example.com/ws?token=<gateway-token>
   "id": "string",
   "agent_id": "string",
   "agent_name": "string",
-  "action_type": "deploy" | "shell_command" | "config_change" | "key_rotation" | "trade_execution" | "destructive",
+  "action_type": "deploy" | "shell_command" | "config_change" | "key_rotation" | "trade_execution" | "destructive" | "agent_skill_install",
   "title": "string",
   "description": "string",
   "command": "string",
@@ -150,12 +154,82 @@ wss://gateway.example.com/ws?token=<gateway-token>
       "reasons": ["string"],
       "recommended_questions": ["string"],
       "recommended_rotations": ["string"]
+    },
+    "agent_commerce": {
+      "detected": true,
+      "category": "cloud_account_provisioning" | "paid_subscription" | "domain_registration" | "api_token_minting" | "deployment" | "mixed",
+      "provider": "cloudflare" | "stripe_projects" | "unknown",
+      "severity": "high" | "critical",
+      "requires_explicit_approval": true,
+      "reasons": ["string"],
+      "recommended_questions": ["string"],
+      "budget": {
+        "currency": "USD",
+        "monthly_limit_usd": 100,
+        "estimated_monthly_usd": 12,
+        "over_budget": false,
+        "requires_budget_confirmation": false
+      },
+      "artifacts": {
+        "domains": ["openclaw.dev"],
+        "services": ["cloudflare/registrar:domain"]
+      }
     }
   },
   "created_at": "ISO8601",
   "expires_at": "ISO8601"
 }
 ```
+
+### SkillWorkflowSystem
+```json
+{
+  "id": "skill-workflow:video-to-brief:abc123",
+  "agent_id": "agent-1",
+  "name": "Video-to-brief orchestrator",
+  "trigger_prompt": "Create a strategic brief from a video URL",
+  "status": "draft" | "active" | "archived",
+  "steps": [
+    {
+      "id": "step-1",
+      "order": 1,
+      "skill_name": "transcript-extractor",
+      "input_requirements": ["video_url"],
+      "consumes_from": [],
+      "output_contract": ["clean transcript markdown"],
+      "produces": ["transcript_md"],
+      "human_checkpoint": false,
+      "artifacts": []
+    }
+  ],
+  "checkpoints": [
+    {
+      "id": "checkpoint-1",
+      "title": "Approve high-ROI item list",
+      "after_step_id": "step-2",
+      "required": true,
+      "approval_action_type": "propose_fix"
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact-1",
+      "label": "Operator dashboard",
+      "type": "html",
+      "path": "artifacts/operator-dashboard.html"
+    }
+  ],
+  "validation": {
+    "valid": true,
+    "errors": [],
+    "warnings": [],
+    "ordered_step_ids": ["step-1"]
+  }
+}
+```
+
+### Background Bridge Controls
+Bridge sessions may represent cloud background agents using `type: "background_agent"` with execution metadata for workflow ID, sandbox ID/state, repository, branch, PR URL, dev server URL, and read-only share URL. `POST /api/bridges/:id/control` accepts `cancel`, `pause`, `resume`, `hibernate`, or `share_readonly` and records a governance event for mobile audit.
 
 ### SecretExposureInventory
 ```json

--- a/openclaw-skills/src/gateway/policy.ts
+++ b/openclaw-skills/src/gateway/policy.ts
@@ -39,6 +39,10 @@ export function evaluateApprovalPolicy(
     return deny(preset, `${input.actionType} is never auto-approved`);
   }
 
+  if (input.context.supply_chain?.requires_explicit_approval) {
+    return deny(preset, `supply-chain ${input.context.supply_chain.category} risk requires explicit approval`);
+  }
+
   if (input.context.risk_level === 'critical' && preset !== 'danger-yolo') {
     return deny(preset, 'critical risk requires explicit approval');
   }

--- a/openclaw-skills/src/gateway/policy.ts
+++ b/openclaw-skills/src/gateway/policy.ts
@@ -43,6 +43,11 @@ export function evaluateApprovalPolicy(
     return deny(preset, `supply-chain ${input.context.supply_chain.category} risk requires explicit approval`);
   }
 
+  if (input.context.agent_commerce?.requires_explicit_approval) {
+    const budgetReason = input.context.agent_commerce.budget.over_budget ? ' and exceeds budget' : '';
+    return deny(preset, `agent commerce ${input.context.agent_commerce.category} risk requires explicit approval${budgetReason}`);
+  }
+
   if (input.context.risk_level === 'critical' && preset !== 'danger-yolo') {
     return deny(preset, 'critical risk requires explicit approval');
   }

--- a/openclaw-skills/src/gateway/project-session.ts
+++ b/openclaw-skills/src/gateway/project-session.ts
@@ -10,6 +10,8 @@ export interface ProjectBridgeSessionMetadata {
   session_scope: 'project';
 }
 
+type BridgeSessionControls = NonNullable<BridgeSession['controls']>;
+
 export function normalizeProjectBridgeSession(input: BridgeSession): BridgeSession {
   const cwd = input.cwd || process.cwd();
   const projectName = slugify(path.basename(cwd) || 'workspace');
@@ -32,7 +34,118 @@ export function normalizeProjectBridgeSession(input: BridgeSession): BridgeSessi
     id: projectSessionId,
     title: input.title || `OpenClaw: ${projectName}`,
     cwd,
+    lifecycle: input.lifecycle ?? (input.closed ? 'completed' : 'running'),
+    controls: normalizeBridgeControls(input),
     metadata,
+  };
+}
+
+export type BridgeSessionControlAction = 'cancel' | 'pause' | 'resume' | 'hibernate' | 'share_readonly';
+
+export function isBridgeSessionControlAction(value: unknown): value is BridgeSessionControlAction {
+  return typeof value === 'string' && ['cancel', 'pause', 'resume', 'hibernate', 'share_readonly'].includes(value);
+}
+
+export function applyBridgeSessionControl(
+  session: BridgeSession,
+  action: BridgeSessionControlAction,
+  params: { readOnlyShareUrl?: string; actor?: string } = {},
+): BridgeSession {
+  const now = new Date().toISOString();
+  const controls = normalizeBridgeControls(session);
+  const metadata = {
+    ...session.metadata,
+    last_control_action: action,
+    last_control_actor: params.actor ?? 'gateway',
+    last_control_at: now,
+  };
+
+  if (action === 'cancel') {
+    if (!controls.can_cancel) return { ...session, controls, metadata };
+    return {
+      ...session,
+      closed: true,
+      lifecycle: 'cancelled',
+      updated_at: now,
+      controls: { ...controls, can_cancel: false, can_pause: false, can_resume: false, can_hibernate: false },
+      metadata,
+    };
+  }
+
+  if (action === 'pause') {
+    if (!controls.can_pause) return { ...session, controls, metadata };
+    return {
+      ...session,
+      lifecycle: 'paused',
+      updated_at: now,
+      controls: { ...controls, can_pause: false, can_resume: true },
+      execution: {
+        ...session.execution,
+        provider: session.execution?.provider ?? 'other',
+        sandbox_state: 'paused',
+      },
+      metadata,
+    };
+  }
+
+  if (action === 'resume') {
+    if (!controls.can_resume) return { ...session, controls, metadata };
+    return {
+      ...session,
+      closed: false,
+      lifecycle: 'running',
+      updated_at: now,
+      controls: { ...controls, can_pause: true, can_resume: false },
+      execution: {
+        ...session.execution,
+        provider: session.execution?.provider ?? 'other',
+        sandbox_state: 'running',
+      },
+      metadata,
+    };
+  }
+
+  if (action === 'hibernate') {
+    if (!controls.can_hibernate) return { ...session, controls, metadata };
+    return {
+      ...session,
+      lifecycle: 'hibernated',
+      updated_at: now,
+      controls: { ...controls, can_pause: false, can_resume: true },
+      execution: {
+        ...session.execution,
+        provider: session.execution?.provider ?? 'other',
+        sandbox_state: 'hibernated',
+      },
+      metadata,
+    };
+  }
+
+  if (!controls.can_share_readonly || !params.readOnlyShareUrl) {
+    return { ...session, controls, metadata };
+  }
+  return {
+    ...session,
+    updated_at: now,
+    controls,
+    execution: {
+      ...session.execution,
+      provider: session.execution?.provider ?? 'other',
+      read_only_share_url: params.readOnlyShareUrl,
+    },
+    metadata,
+  };
+}
+
+function normalizeBridgeControls(session: BridgeSession): BridgeSessionControls {
+  const lifecycle = session.lifecycle ?? (session.closed ? 'completed' : 'running');
+  const active = !session.closed && !['cancelled', 'failed', 'completed'].includes(lifecycle);
+  return {
+    can_cancel: session.controls?.can_cancel ?? active,
+    can_pause: session.controls?.can_pause ?? (active && lifecycle === 'running'),
+    can_resume: session.controls?.can_resume ?? (lifecycle === 'paused' || lifecycle === 'hibernated'),
+    can_hibernate: session.controls?.can_hibernate ?? active,
+    can_share_readonly: session.controls?.can_share_readonly ?? true,
   };
 }
 

--- a/openclaw-skills/src/gateway/server.ts
+++ b/openclaw-skills/src/gateway/server.ts
@@ -41,10 +41,16 @@ import {
   isResponseProfile,
   isResponseVerbosity,
 } from '../config/default.js';
-import { normalizeProjectBridgeSession } from './project-session.js';
+import {
+  applyBridgeSessionControl,
+  isBridgeSessionControlAction,
+  normalizeProjectBridgeSession,
+} from './project-session.js';
+import { normalizeSkillWorkflowSystem } from './skill-workflow.js';
 import { buildOperatorSummary } from './operator-summary.js';
 import { presentTaskForOperator } from '../utils/response-style.js';
 import {
+  assessAgentCommerceRisk,
   assessSupplyChainRisk,
   scanSecretExposureInventory,
 } from '../security/supply-chain-guardrails.js';
@@ -385,6 +391,28 @@ export function createGatewayServer(
     });
   });
 
+  app.post('/api/security/agent-commerce/assess', auth, (req: Request, res: Response) => {
+    const command = typeof req.body?.command === 'string' ? req.body.command : '';
+    const actionType = isActionType(req.body?.action_type) ? req.body.action_type : 'shell_command';
+    const estimatedMonthlyUsd = parseOptionalUsd(req.body?.estimated_monthly_usd);
+    const monthlyBudgetLimitUsd = parseOptionalUsd(req.body?.monthly_budget_limit_usd);
+    if (!command) {
+      res.status(400).json({ error: { code: 4000, message: 'command is required' } });
+      return;
+    }
+    const risk = assessAgentCommerceRisk({
+      actionType,
+      command,
+      estimatedMonthlyUsd,
+      monthlyBudgetLimitUsd,
+    });
+    res.json({
+      checked_at: new Date().toISOString(),
+      detected: risk !== null,
+      risk,
+    });
+  });
+
   app.get('/api/security/secret-inventory', auth, (_req: Request, res: Response) => {
     res.json(scanSecretExposureInventory({ rootDir: process.cwd() }));
   });
@@ -431,6 +459,62 @@ export function createGatewayServer(
   app.post('/api/bridges/upsert', auth, async (req: Request, res: Response) => {
     const session = await state.upsertBridgeSession(normalizeProjectBridgeSession(req.body));
     res.json(session);
+  });
+
+  app.post('/api/bridges/:id/control', auth, async (req: Request, res: Response) => {
+    const bridgeId = String(req.params['id'] ?? '');
+    const session = state.listBridgeSessions().find((item) => item.id === bridgeId);
+    if (!session) {
+      res.status(404).json({ error: { code: 4040, message: 'Bridge session not found' } });
+      return;
+    }
+    if (!isBridgeSessionControlAction(req.body?.action)) {
+      res.status(400).json({ error: { code: 4000, message: 'action must be cancel, pause, resume, hibernate, or share_readonly' } });
+      return;
+    }
+    const actor = parseActor(req.body?.actor);
+    const updated = applyBridgeSessionControl(session, req.body.action, {
+      actor,
+      readOnlyShareUrl: typeof req.body?.read_only_share_url === 'string' ? req.body.read_only_share_url : undefined,
+    });
+    const stored = await state.upsertBridgeSession(updated);
+    await state.recordGovernanceEvent?.({
+      agent_id: stored.agent_id,
+      type: 'environment_observed',
+      title: `Bridge session ${req.body.action}`,
+      summary: `Applied ${req.body.action} to ${stored.title}`,
+      actor,
+      risk_level: 'high',
+      metadata: {
+        bridge_id: stored.id,
+        lifecycle: stored.lifecycle,
+        execution: stored.execution,
+      },
+    });
+    res.json(stored);
+  });
+
+  // ── Skill Workflow Systems ───────────────────────────────────────────────
+
+  app.get('/api/skill-workflows', auth, (req: Request, res: Response) => {
+    const agentId = typeof req.query['agent_id'] === 'string' ? req.query['agent_id'] : undefined;
+    res.json(state.listSkillWorkflowSystems(agentId));
+  });
+
+  app.post('/api/skill-workflows/upsert', auth, async (req: Request, res: Response) => {
+    const agentId = typeof req.body?.agent_id === 'string' ? req.body.agent_id : '';
+    if (!agentId || !state.getAgent(agentId)) {
+      res.status(404).json({ error: { code: ERROR_CODES.AGENT_NOT_FOUND, message: 'Agent not found' } });
+      return;
+    }
+    if (typeof req.body?.name !== 'string' || typeof req.body?.trigger_prompt !== 'string' || !Array.isArray(req.body?.steps)) {
+      res.status(400).json({ error: { code: 4000, message: 'agent_id, name, trigger_prompt, and steps are required' } });
+      return;
+    }
+    const existing = typeof req.body?.id === 'string' ? state.getSkillWorkflowSystem(req.body.id) : undefined;
+    const workflow = normalizeSkillWorkflowSystem(req.body, existing);
+    const stored = await state.upsertSkillWorkflowSystem(workflow);
+    res.status(stored.validation.valid ? 200 : 422).json(stored);
   });
 
   // ── Recurring Tasks (Loops) ───────────────────────────────────────────────
@@ -626,4 +710,11 @@ export function createGatewayServer(
 
   function parseActor(value: unknown): GovernanceEvent['actor'] {
     return value === 'human' || value === 'gateway' || value === 'policy' ? value : 'agent';
+  }
+
+  function parseOptionalUsd(value: unknown): number | undefined {
+    if (value === undefined || value === null || value === '') return undefined;
+    const parsed = typeof value === 'number' ? value : Number.parseFloat(String(value));
+    if (!Number.isFinite(parsed) || parsed < 0) return undefined;
+    return Math.round(parsed * 100) / 100;
   }

--- a/openclaw-skills/src/gateway/server.ts
+++ b/openclaw-skills/src/gateway/server.ts
@@ -44,6 +44,11 @@ import {
 import { normalizeProjectBridgeSession } from './project-session.js';
 import { buildOperatorSummary } from './operator-summary.js';
 import { presentTaskForOperator } from '../utils/response-style.js';
+import {
+  assessSupplyChainRisk,
+  scanSecretExposureInventory,
+} from '../security/supply-chain-guardrails.js';
+import { IncidentManagerSkill } from '../skills/incident-manager.js';
 
 export interface GatewayServer {
   httpServer: http.Server;
@@ -69,6 +74,7 @@ export function createGatewayServer(
   const containerManager = new DockerContainerManager(config);
   const mcpManager = new McpManager();
   const skillGenerator = new SkillGenerator(containerManager, mcpManager, state);
+  const incidentManager = new IncidentManagerSkill(state);
 
   // ── Middleware ───────────────────────────────────────────────────────────
 
@@ -357,6 +363,59 @@ export function createGatewayServer(
 
   app.get('/api/incidents', auth, (_req: Request, res: Response) => {
     res.json(state.listIncidents());
+  });
+
+  // ── Supply-Chain Guardrails ──────────────────────────────────────────────
+
+  app.post('/api/security/supply-chain/assess', auth, (req: Request, res: Response) => {
+    const command = typeof req.body?.command === 'string' ? req.body.command : '';
+    const fileChanges = Array.isArray(req.body?.file_changes)
+      ? req.body.file_changes.filter((item: unknown): item is string => typeof item === 'string')
+      : undefined;
+    const actionType = isActionType(req.body?.action_type) ? req.body.action_type : 'shell_command';
+    if (!command && (!fileChanges || fileChanges.length === 0)) {
+      res.status(400).json({ error: { code: 4000, message: 'command or file_changes is required' } });
+      return;
+    }
+    const risk = assessSupplyChainRisk({ actionType, command, fileChanges });
+    res.json({
+      checked_at: new Date().toISOString(),
+      detected: risk !== null,
+      risk,
+    });
+  });
+
+  app.get('/api/security/secret-inventory', auth, (req: Request, res: Response) => {
+    const rawRoot = typeof req.query['root'] === 'string' ? req.query['root'] : process.cwd();
+    res.json(scanSecretExposureInventory({ rootDir: rawRoot }));
+  });
+
+  app.post('/api/security/supply-chain/incidents', auth, async (req: Request, res: Response) => {
+    const agentId = typeof req.body?.agent_id === 'string' ? req.body.agent_id : '';
+    const agent = agentId ? state.getAgent(agentId) : null;
+    if (!agent) {
+      res.status(404).json({ error: { code: ERROR_CODES.AGENT_NOT_FOUND, message: 'Agent not found' } });
+      return;
+    }
+    const title = typeof req.body?.title === 'string' && req.body.title.trim()
+      ? req.body.title.trim()
+      : 'Suspected developer-machine supply-chain exposure';
+    const command = typeof req.body?.command === 'string' ? req.body.command : undefined;
+    const repository = typeof req.body?.repository === 'string' ? req.body.repository : undefined;
+    const inventoryRoot = typeof req.body?.inventory_root === 'string' ? req.body.inventory_root : process.cwd();
+    const inventory = scanSecretExposureInventory({ rootDir: inventoryRoot });
+    const incident = await incidentManager.createSupplyChainIncident({
+      agentId,
+      agentName: agent.name,
+      title,
+      command,
+      repository,
+      inventory,
+    });
+    res.json({
+      incident,
+      inventory_counts: inventory.counts,
+    });
   });
 
   // ── Approvals ─────────────────────────────────────────────────────────────

--- a/openclaw-skills/src/gateway/server.ts
+++ b/openclaw-skills/src/gateway/server.ts
@@ -385,9 +385,8 @@ export function createGatewayServer(
     });
   });
 
-  app.get('/api/security/secret-inventory', auth, (req: Request, res: Response) => {
-    const rawRoot = typeof req.query['root'] === 'string' ? req.query['root'] : process.cwd();
-    res.json(scanSecretExposureInventory({ rootDir: rawRoot }));
+  app.get('/api/security/secret-inventory', auth, (_req: Request, res: Response) => {
+    res.json(scanSecretExposureInventory({ rootDir: process.cwd() }));
   });
 
   app.post('/api/security/supply-chain/incidents', auth, async (req: Request, res: Response) => {
@@ -402,8 +401,7 @@ export function createGatewayServer(
       : 'Suspected developer-machine supply-chain exposure';
     const command = typeof req.body?.command === 'string' ? req.body.command : undefined;
     const repository = typeof req.body?.repository === 'string' ? req.body.repository : undefined;
-    const inventoryRoot = typeof req.body?.inventory_root === 'string' ? req.body.inventory_root : process.cwd();
-    const inventory = scanSecretExposureInventory({ rootDir: inventoryRoot });
+    const inventory = scanSecretExposureInventory({ rootDir: process.cwd() });
     const incident = await incidentManager.createSupplyChainIncident({
       agentId,
       agentName: agent.name,

--- a/openclaw-skills/src/gateway/skill-workflow.ts
+++ b/openclaw-skills/src/gateway/skill-workflow.ts
@@ -1,0 +1,190 @@
+import crypto from 'node:crypto';
+import type {
+  ActionType,
+  SkillWorkflowArtifact,
+  SkillWorkflowCheckpoint,
+  SkillWorkflowStep,
+  SkillWorkflowSystem,
+  SkillWorkflowValidation,
+} from '../types/protocol.js';
+
+export interface SkillWorkflowUpsertRequest {
+  id?: string;
+  agent_id: string;
+  name: string;
+  description?: string;
+  version?: string;
+  trigger_prompt: string;
+  status?: SkillWorkflowSystem['status'];
+  steps: Array<Partial<SkillWorkflowStep> & {
+    skill_name: string;
+    title?: string;
+  }>;
+  checkpoints?: Array<Partial<SkillWorkflowCheckpoint> & {
+    title: string;
+    after_step_id: string;
+  }>;
+  artifacts?: Array<Partial<SkillWorkflowArtifact> & {
+    label: string;
+    type: SkillWorkflowArtifact['type'];
+  }>;
+  metadata?: Record<string, unknown>;
+}
+
+export function normalizeSkillWorkflowSystem(
+  input: SkillWorkflowUpsertRequest,
+  existing?: SkillWorkflowSystem,
+): SkillWorkflowSystem {
+  const now = new Date().toISOString();
+  const steps = normalizeSteps(input.steps ?? []);
+  const checkpoints = normalizeCheckpoints(input.checkpoints ?? []);
+  const artifacts = normalizeArtifacts(input.artifacts ?? []);
+  const workflow: SkillWorkflowSystem = {
+    id: input.id?.trim() || existing?.id || stableWorkflowId(input.agent_id, input.name),
+    agent_id: input.agent_id,
+    name: input.name.trim(),
+    description: input.description?.trim() || existing?.description || '',
+    version: input.version?.trim() || existing?.version || '1.0.0',
+    trigger_prompt: input.trigger_prompt.trim(),
+    status: input.status ?? existing?.status ?? 'draft',
+    steps,
+    checkpoints,
+    artifacts,
+    validation: validateSkillWorkflowSystem({
+      steps,
+      checkpoints,
+      artifacts,
+    }),
+    created_at: existing?.created_at ?? now,
+    updated_at: now,
+    metadata: input.metadata ?? existing?.metadata ?? {},
+  };
+  return workflow;
+}
+
+export function validateSkillWorkflowSystem(input: {
+  steps: SkillWorkflowStep[];
+  checkpoints: SkillWorkflowCheckpoint[];
+  artifacts: SkillWorkflowArtifact[];
+}): SkillWorkflowValidation {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const orderedSteps = [...input.steps].sort((left, right) => left.order - right.order);
+  const stepIds = new Set<string>();
+  const producedOutputs = new Set<string>();
+
+  if (orderedSteps.length === 0) {
+    errors.push('At least one workflow step is required.');
+  }
+
+  for (const step of orderedSteps) {
+    if (stepIds.has(step.id)) {
+      errors.push(`Duplicate step id: ${step.id}`);
+    }
+    stepIds.add(step.id);
+    if (!step.skill_name.trim()) errors.push(`Step ${step.id} is missing skill_name.`);
+    if (step.input_requirements.length === 0) warnings.push(`Step ${step.id} has no input requirements.`);
+    if (step.output_contract.length === 0) errors.push(`Step ${step.id} is missing output_contract.`);
+    if (step.produces.length === 0) warnings.push(`Step ${step.id} does not declare produced handoff keys.`);
+    for (const dependency of step.consumes_from) {
+      if (!producedOutputs.has(dependency)) {
+        errors.push(`Step ${step.id} consumes "${dependency}" before any earlier step produces it.`);
+      }
+    }
+    for (const output of step.produces) {
+      producedOutputs.add(output);
+    }
+  }
+
+  for (const checkpoint of input.checkpoints) {
+    if (!stepIds.has(checkpoint.after_step_id)) {
+      errors.push(`Checkpoint ${checkpoint.id} references missing step ${checkpoint.after_step_id}.`);
+    }
+  }
+
+  if (!input.checkpoints.some((checkpoint) => checkpoint.required)) {
+    warnings.push('No required human-in-the-loop checkpoint is declared.');
+  }
+  if (input.artifacts.length === 0 && !orderedSteps.some((step) => step.artifacts.length > 0)) {
+    warnings.push('No visual/result artifact is declared.');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    ordered_step_ids: orderedSteps.map((step) => step.id),
+  };
+}
+
+function normalizeSteps(steps: SkillWorkflowUpsertRequest['steps']): SkillWorkflowStep[] {
+  return steps.map((step, index) => ({
+    id: step.id?.trim() || `step-${index + 1}`,
+    order: Number.isInteger(step.order) ? Number(step.order) : index + 1,
+    skill_name: step.skill_name.trim(),
+    title: step.title?.trim() || step.skill_name.trim(),
+    input_requirements: normalizeStrings(step.input_requirements),
+    consumes_from: normalizeStrings(step.consumes_from),
+    output_contract: normalizeStrings(step.output_contract),
+    produces: normalizeStrings(step.produces),
+    human_checkpoint: step.human_checkpoint ?? false,
+    artifacts: normalizeArtifacts(step.artifacts ?? []),
+  }));
+}
+
+function normalizeCheckpoints(checkpoints: SkillWorkflowUpsertRequest['checkpoints']): SkillWorkflowCheckpoint[] {
+  return (checkpoints ?? []).map((checkpoint, index) => ({
+    id: checkpoint.id?.trim() || `checkpoint-${index + 1}`,
+    title: checkpoint.title.trim(),
+    after_step_id: checkpoint.after_step_id.trim(),
+    required: checkpoint.required ?? true,
+    approval_action_type: normalizeActionType(checkpoint.approval_action_type),
+  }));
+}
+
+function normalizeArtifacts(artifacts: SkillWorkflowUpsertRequest['artifacts']): SkillWorkflowArtifact[] {
+  return (artifacts ?? []).map((artifact, index) => ({
+    id: artifact.id?.trim() || `artifact-${index + 1}`,
+    label: artifact.label.trim(),
+    type: artifact.type,
+    path: artifact.path?.trim() || undefined,
+    url: artifact.url?.trim() || undefined,
+  }));
+}
+
+function normalizeStrings(values: unknown): string[] {
+  return Array.isArray(values)
+    ? values.filter((value): value is string => typeof value === 'string' && value.trim().length > 0).map((value) => value.trim())
+    : [];
+}
+
+function normalizeActionType(value: unknown): ActionType | undefined {
+  return typeof value === 'string' && [
+    'deploy',
+    'shell_command',
+    'config_change',
+    'key_rotation',
+    'trade_execution',
+    'destructive',
+    'ask_root_cause',
+    'propose_fix',
+    'acknowledge',
+    'git_commit',
+    'git_merge',
+    'git_push',
+    'agent_skill_install',
+    'agent_rollback',
+  ].includes(value) ? value as ActionType : undefined;
+}
+
+function stableWorkflowId(agentId: string, name: string): string {
+  const hash = crypto.createHash('sha256').update(`${agentId}:${name}`).digest('hex').slice(0, 10);
+  return `skill-workflow:${slugify(name)}:${hash}`;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '') || 'workflow';
+}

--- a/openclaw-skills/src/gateway/state-interface.ts
+++ b/openclaw-skills/src/gateway/state-interface.ts
@@ -14,6 +14,7 @@ import type {
   ApprovalResponse,
   BridgeSession,
   RecurringTask,
+  SkillWorkflowSystem,
   AgentGovernanceState,
   AgentPlanStep,
   AgentPlanStepStatus,
@@ -74,6 +75,10 @@ export interface IStateManager {
 
   upsertRecurringTask?(task: RecurringTask): Promise<RecurringTask>;
   listRecurringTasks?(): Promise<RecurringTask[]> | RecurringTask[];
+
+  upsertSkillWorkflowSystem?(workflow: SkillWorkflowSystem): Promise<SkillWorkflowSystem>;
+  listSkillWorkflowSystems?(agentId?: string): Promise<SkillWorkflowSystem[]> | SkillWorkflowSystem[];
+  getSkillWorkflowSystem?(id: string): Promise<SkillWorkflowSystem | undefined> | SkillWorkflowSystem | undefined;
 
   getAgentGovernance?(agentId: string): Promise<AgentGovernanceState> | AgentGovernanceState;
   updateAgentObjective?(agentId: string, objective: string, actor?: GovernanceEvent['actor']): Promise<AgentGovernanceState>;

--- a/openclaw-skills/src/gateway/state.ts
+++ b/openclaw-skills/src/gateway/state.ts
@@ -26,6 +26,7 @@ import type {
   ResourceLink,
   BridgeSession,
   RecurringTask,
+  SkillWorkflowSystem,
   AgentGovernanceState,
   AgentPlanStep,
   AgentPlanStepStatus,
@@ -52,6 +53,7 @@ export interface StateEvents {
   bridge_session_new: [session: BridgeSession];
   bridge_session_update: [session: BridgeSession];
   recurring_task_updated: [task: RecurringTask];
+  skill_workflow_updated: [workflow: SkillWorkflowSystem];
   governance_event: [event: GovernanceEvent];
 }
 
@@ -99,6 +101,7 @@ export class StateManager implements IStateManager {
   private approvals: Map<string, PendingApproval> = new Map();
   private bridgeSessions: Map<string, BridgeSession> = new Map();
   private recurringTasks: Map<string, RecurringTask> = new Map();
+  private skillWorkflowSystems: Map<string, SkillWorkflowSystem> = new Map();
   private governanceStates: Map<string, AgentGovernanceState> = new Map();
   private governanceEvents: GovernanceEvent[] = [];
   private readonly governanceEventLogPath: string | null;
@@ -464,6 +467,40 @@ export class StateManager implements IStateManager {
 
   public listRecurringTasks(): RecurringTask[] {
     return Array.from(this.recurringTasks.values());
+  }
+
+  // ── Skill Workflow Systems ───────────────────────────────────────────────
+
+  public async upsertSkillWorkflowSystem(workflow: SkillWorkflowSystem): Promise<SkillWorkflowSystem> {
+    this.skillWorkflowSystems.set(workflow.id, workflow);
+    this.events.emit('skill_workflow_updated', workflow);
+    await this.recordGovernanceEvent({
+      agent_id: workflow.agent_id,
+      type: 'skill_workflow_registered',
+      title: workflow.name,
+      summary: workflow.validation.valid
+        ? `Registered skill workflow with ${workflow.steps.length} step(s)`
+        : `Registered invalid skill workflow with ${workflow.validation.errors.length} validation error(s)`,
+      actor: 'gateway',
+      risk_level: workflow.validation.valid ? 'high' : 'critical',
+      metadata: {
+        workflow_id: workflow.id,
+        status: workflow.status,
+        validation: workflow.validation,
+        checkpoints: workflow.checkpoints.length,
+        artifacts: workflow.artifacts.length,
+      },
+    });
+    return workflow;
+  }
+
+  public listSkillWorkflowSystems(agentId?: string): SkillWorkflowSystem[] {
+    const workflows = Array.from(this.skillWorkflowSystems.values());
+    return agentId ? workflows.filter((workflow) => workflow.agent_id === agentId) : workflows;
+  }
+
+  public getSkillWorkflowSystem(id: string): SkillWorkflowSystem | undefined {
+    return this.skillWorkflowSystems.get(id);
   }
 
   // ── Governance ───────────────────────────────────────────────────────────

--- a/openclaw-skills/src/security/supply-chain-guardrails.ts
+++ b/openclaw-skills/src/security/supply-chain-guardrails.ts
@@ -1,0 +1,437 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ActionType, RiskLevel, SupplyChainRisk } from '../types/protocol.js';
+
+export interface SupplyChainRiskInput {
+  actionType?: ActionType;
+  command?: string;
+  fileChanges?: string[];
+}
+
+export interface SecretExposureInventoryOptions {
+  rootDir: string;
+  env?: NodeJS.ProcessEnv;
+  maxFiles?: number;
+}
+
+export interface SecretExposureInventory {
+  root_dir: string;
+  checked_at: string;
+  env_secret_key_names: string[];
+  local_secret_files: Array<{
+    path: string;
+    key_names: string[];
+  }>;
+  github_actions_secret_references: string[];
+  package_manifests: string[];
+  counts: {
+    env_secret_keys: number;
+    local_secret_files: number;
+    local_secret_key_names: number;
+    github_actions_secret_references: number;
+    package_manifests: number;
+  };
+}
+
+const SUPPLY_CHAIN_PATTERNS: Array<{
+  pattern: RegExp;
+  category: SupplyChainRisk['category'];
+  severity: RiskLevel;
+  reason: string;
+  requiredApproval: boolean;
+}> = [
+  {
+    pattern: /\b(npm|pnpm|yarn)\s+(install|i|add|upgrade|update|create|exec|dlx)\b/i,
+    category: 'dependency_install',
+    severity: 'critical',
+    reason: 'JavaScript package commands can execute lifecycle scripts and harvest developer credentials.',
+    requiredApproval: true,
+  },
+  {
+    pattern: /\bnpm\s+ci\b/i,
+    category: 'dependency_install',
+    severity: 'high',
+    reason: 'Lockfile installs still execute package lifecycle scripts on the developer machine.',
+    requiredApproval: true,
+  },
+  {
+    pattern: /\b(pip|pip3|pipx|poetry|uv)\s+(install|add|sync|run|tool\s+install)\b/i,
+    category: 'dependency_install',
+    severity: 'critical',
+    reason: 'Python package installation can execute setup hooks and expose local credentials.',
+    requiredApproval: true,
+  },
+  {
+    pattern: /\b(docker|podman)\s+(pull|run|build|compose\s+up|login)\b/i,
+    category: 'container_image',
+    severity: 'critical',
+    reason: 'Container image operations can run untrusted code or access mounted credentials.',
+    requiredApproval: true,
+  },
+  {
+    pattern: /\b(curl|wget)\b.*\|\s*(sh|bash|zsh|python|python3|node)\b/i,
+    category: 'remote_script',
+    severity: 'critical',
+    reason: 'Piping remote content into an interpreter executes unaudited code on the developer machine.',
+    requiredApproval: true,
+  },
+  {
+    pattern: /\b(brew|gem|cargo|go)\s+(install|get)\b/i,
+    category: 'cli_install',
+    severity: 'critical',
+    reason: 'CLI installation changes the trusted toolchain used by future agent actions.',
+    requiredApproval: true,
+  },
+  {
+    pattern: /\b(gh|github|npm|docker|gcloud|az|vercel|flyctl|stripe)\s+.*\b(auth|login|token|secret|credential|configure)\b/i,
+    category: 'credential_command',
+    severity: 'critical',
+    reason: 'Credential and auth commands can expose, mint, or mutate high-value non-human identities.',
+    requiredApproval: true,
+  },
+  {
+    pattern: /\baws\s+.*\b(auth|login|secret|credential|configure)\b/i,
+    category: 'credential_command',
+    severity: 'critical',
+    reason: 'Credential and auth commands can expose, mint, or mutate high-value non-human identities.',
+    requiredApproval: true,
+  },
+  {
+    pattern: /\b(cat|less|more|head|tail|sed|awk|grep|rg|git\s+show)\b.*(\.env|\.npmrc|\.pypirc|\.netrc|credentials|secrets?|token|keychain)/i,
+    category: 'secret_touch',
+    severity: 'critical',
+    reason: 'The command may read secret-bearing files or credential names into agent context.',
+    requiredApproval: true,
+  },
+  {
+    pattern: /\b(claude|codex|cursor|aider|gemini|grok)\b.*\b(install|mcp|tool|plugin|extension)\b/i,
+    category: 'agent_tooling',
+    severity: 'critical',
+    reason: 'Agent tool/plugin changes can expand what future autonomous actions can access.',
+    requiredApproval: true,
+  },
+];
+
+const SECRET_FILE_BASENAMES = new Set([
+  '.env',
+  '.env.local',
+  '.env.development',
+  '.env.production',
+  '.env.staging',
+  '.npmrc',
+  '.pypirc',
+  '.netrc',
+  'credentials',
+  'secrets.json',
+  'service-account.json',
+]);
+
+const PACKAGE_MANIFEST_BASENAMES = new Set([
+  'package.json',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+  'requirements.txt',
+  'pyproject.toml',
+  'poetry.lock',
+  'Dockerfile',
+  'docker-compose.yml',
+  'docker-compose.yaml',
+]);
+
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  '.gradle',
+  '.next',
+  'DerivedData',
+]);
+
+const SECRET_KEY_PATTERN = /(SECRET|TOKEN|KEY|PASSWORD|PASS|CREDENTIAL|PRIVATE|APPSTORE|STRIPE|REVENUECAT|GITHUB|GH_|XAI|OPENAI|ANTHROPIC|GEMINI|FIREBASE|SLACK|AWS|GCP|AZURE|DOCKER|NPM)/i;
+
+export function assessSupplyChainRisk(input: SupplyChainRiskInput): SupplyChainRisk | null {
+  const command = input.command?.trim() ?? '';
+  const fileChanges = input.fileChanges ?? [];
+  const matches = SUPPLY_CHAIN_PATTERNS.filter((entry) => command && entry.pattern.test(command));
+
+  for (const file of fileChanges) {
+    const normalized = file.replaceAll('\\', '/');
+    if (isSecretBearingPath(normalized)) {
+      matches.push({
+        pattern: /.*/,
+        category: 'secret_touch',
+        severity: 'critical',
+        reason: `Changes include secret-bearing path "${normalized}".`,
+        requiredApproval: true,
+      });
+      break;
+    }
+    if (isPackageManifest(normalized)) {
+      matches.push({
+        pattern: /.*/,
+        category: 'dependency_install',
+        severity: 'critical',
+        reason: `Changes include dependency or container manifest "${normalized}".`,
+        requiredApproval: true,
+      });
+      break;
+    }
+  }
+
+  if (input.actionType === 'agent_skill_install') {
+    matches.push({
+      pattern: /.*/,
+      category: 'agent_tooling',
+      severity: 'critical',
+      reason: 'Installing agent skills expands future agent capability and access.',
+      requiredApproval: true,
+    });
+  }
+
+  if (matches.length === 0) return null;
+
+  const severity: RiskLevel = matches.some((match) => match.severity === 'critical') ? 'critical' : 'high';
+  const categories = Array.from(new Set(matches.map((match) => match.category)));
+  return {
+    detected: true,
+    category: categories.length === 1 ? categories[0]! : 'mixed',
+    severity,
+    requires_explicit_approval: matches.some((match) => match.requiredApproval),
+    reasons: Array.from(new Set(matches.map((match) => match.reason))),
+    recommended_questions: recommendedQuestions(categories),
+    recommended_rotations: recommendedRotations(categories),
+  };
+}
+
+export function appendSupplyChainApprovalSummary(description: string, risk: SupplyChainRisk | null): string {
+  if (!risk) return description;
+  return [
+    description,
+    '',
+    'Supply-chain guardrail:',
+    `Risk: ${risk.severity.toUpperCase()} (${risk.category})`,
+    ...risk.reasons.map((reason) => `- ${reason}`),
+    'Before approving, verify the package/source, expected credential access, and rollback/rotation plan.',
+  ].join('\n');
+}
+
+export function buildSupplyChainIncidentRunbook(params: {
+  title: string;
+  command?: string;
+  risk?: SupplyChainRisk | null;
+  inventory?: SecretExposureInventory | null;
+}): string {
+  const risk = params.risk;
+  const inventory = params.inventory;
+  return [
+    `Supply-chain security workflow for "${params.title}":`,
+    '',
+    risk ? `Risk classification: ${risk.severity.toUpperCase()} ${risk.category}` : 'Risk classification: not provided',
+    params.command ? `Command: ${params.command}` : null,
+    '',
+    'Immediate containment:',
+    '1. Pause the agent session and stop new package/container/tool installs.',
+    '2. Capture evidence: command, package name/version, lockfile diff, image digest, and agent logs.',
+    '3. Review whether local secret-bearing files or environment variables were accessible.',
+    '',
+    'Credential rotation priority:',
+    ...(risk?.recommended_rotations.length ? risk.recommended_rotations.map((item) => `- ${item}`) : [
+      '- Rotate GitHub tokens and package registry tokens first.',
+      '- Rotate cloud, deploy, billing, and app store keys reachable from this machine.',
+    ]),
+    inventory ? '' : null,
+    inventory ? `Inventory counts: ${inventory.counts.env_secret_keys} env key names, ${inventory.counts.local_secret_files} local secret files, ${inventory.counts.github_actions_secret_references} GitHub Actions secret references.` : null,
+    '',
+    'Recovery checklist:',
+    '- Reinstall dependencies from a reviewed lockfile or pinned digest.',
+    '- Revoke suspicious sessions/tokens before resuming the agent.',
+    '- Record the final rotation evidence in the incident timeline.',
+  ].filter((line): line is string => line !== null).join('\n');
+}
+
+export function scanSecretExposureInventory(options: SecretExposureInventoryOptions): SecretExposureInventory {
+  const rootDir = path.resolve(options.rootDir);
+  const maxFiles = options.maxFiles ?? 400;
+  const env = options.env ?? process.env;
+  const envSecretKeyNames = Object.keys(env)
+    .filter((key) => SECRET_KEY_PATTERN.test(key))
+    .sort();
+
+  const localSecretFiles: SecretExposureInventory['local_secret_files'] = [];
+  const githubSecrets = new Set<string>();
+  const packageManifests = new Set<string>();
+  let visited = 0;
+
+  if (fs.existsSync(rootDir)) {
+    walk(rootDir, rootDir, (absolutePath, relativePath) => {
+      if (visited >= maxFiles) return;
+      visited++;
+      const normalized = relativePath.replaceAll('\\', '/');
+      const basename = path.basename(normalized);
+
+      if (isPackageManifest(normalized)) {
+        packageManifests.add(normalized);
+      }
+
+      if (isSecretBearingPath(normalized)) {
+        localSecretFiles.push({
+          path: normalized,
+          key_names: extractSecretKeyNames(absolutePath),
+        });
+      }
+
+      if (normalized.startsWith('.github/workflows/') && /\.(ya?ml)$/i.test(normalized)) {
+        for (const secret of extractGithubActionsSecretReferences(absolutePath)) {
+          githubSecrets.add(secret);
+        }
+      }
+
+      if (SECRET_FILE_BASENAMES.has(basename) && !localSecretFiles.some((file) => file.path === normalized)) {
+        localSecretFiles.push({
+          path: normalized,
+          key_names: extractSecretKeyNames(absolutePath),
+        });
+      }
+    });
+  }
+
+  const uniqueLocalSecretFiles = dedupeSecretFiles(localSecretFiles);
+  const localSecretKeyCount = uniqueLocalSecretFiles.reduce((sum, file) => sum + file.key_names.length, 0);
+
+  return {
+    root_dir: rootDir,
+    checked_at: new Date().toISOString(),
+    env_secret_key_names: envSecretKeyNames,
+    local_secret_files: uniqueLocalSecretFiles,
+    github_actions_secret_references: Array.from(githubSecrets).sort(),
+    package_manifests: Array.from(packageManifests).sort(),
+    counts: {
+      env_secret_keys: envSecretKeyNames.length,
+      local_secret_files: uniqueLocalSecretFiles.length,
+      local_secret_key_names: localSecretKeyCount,
+      github_actions_secret_references: githubSecrets.size,
+      package_manifests: packageManifests.size,
+    },
+  };
+}
+
+function recommendedQuestions(categories: SupplyChainRisk['category'][]): string[] {
+  const questions = [
+    'Is the package, image, script, or tool source pinned and trusted?',
+    'Which local secrets and non-human identities could the command access?',
+    'What is the rollback or credential-rotation plan if this is malicious?',
+  ];
+  if (categories.includes('remote_script')) {
+    questions.unshift('Has the remote script content been downloaded and reviewed before execution?');
+  }
+  if (categories.includes('credential_command') || categories.includes('secret_touch')) {
+    questions.unshift('Will this command print, mint, rotate, or upload credentials?');
+  }
+  return Array.from(new Set(questions));
+}
+
+function recommendedRotations(categories: SupplyChainRisk['category'][]): string[] {
+  const rotations = new Set<string>([
+    'GitHub personal access tokens, fine-grained tokens, and GitHub App credentials',
+    'Package registry tokens for npm, PyPI, Docker Hub, and GitHub Packages',
+  ]);
+  if (categories.includes('container_image')) {
+    rotations.add('Container registry credentials and cloud runtime secrets mounted into builds');
+  }
+  if (categories.includes('credential_command') || categories.includes('secret_touch')) {
+    rotations.add('Cloud provider, billing, app store, analytics, and AI provider API keys visible to the developer machine');
+  }
+  if (categories.includes('agent_tooling')) {
+    rotations.add('Agent bridge tokens, MCP server tokens, and CLI auth sessions');
+  }
+  return Array.from(rotations);
+}
+
+function isSecretBearingPath(filePath: string): boolean {
+  const normalized = filePath.toLowerCase();
+  const basename = path.basename(normalized);
+  return SECRET_FILE_BASENAMES.has(basename) ||
+    normalized.includes('/.env') ||
+    normalized.includes('/secrets/') ||
+    normalized.includes('/credentials') ||
+    normalized.includes('service-account') ||
+    normalized.endsWith('.pem') ||
+    normalized.endsWith('.key');
+}
+
+function isPackageManifest(filePath: string): boolean {
+  const basename = path.basename(filePath);
+  return PACKAGE_MANIFEST_BASENAMES.has(basename) ||
+    filePath.includes('.github/dependabot.yml') ||
+    filePath.includes('.github/dependabot.yaml');
+}
+
+function walk(rootDir: string, currentDir: string, onFile: (absolutePath: string, relativePath: string) => void): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(currentDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory() && SKIP_DIRS.has(entry.name)) continue;
+    const absolutePath = path.join(currentDir, entry.name);
+    const relativePath = path.relative(rootDir, absolutePath);
+    if (entry.isDirectory()) {
+      walk(rootDir, absolutePath, onFile);
+    } else if (entry.isFile()) {
+      onFile(absolutePath, relativePath);
+    }
+  }
+}
+
+function extractSecretKeyNames(filePath: string): string[] {
+  const keyNames = new Set<string>();
+  let contents: string;
+  try {
+    contents = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+
+  for (const line of contents.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const envMatch = trimmed.match(/^(?:export\s+)?([A-Z0-9_][A-Z0-9_.-]*)\s*=/i);
+    if (envMatch?.[1]) {
+      keyNames.add(envMatch[1]);
+    }
+  }
+  return Array.from(keyNames).sort();
+}
+
+function extractGithubActionsSecretReferences(filePath: string): string[] {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+  return Array.from(contents.matchAll(/secrets\.([A-Z0-9_]+)/gi))
+    .map((match) => match[1]!)
+    .sort();
+}
+
+function dedupeSecretFiles(files: SecretExposureInventory['local_secret_files']): SecretExposureInventory['local_secret_files'] {
+  const byPath = new Map<string, SecretExposureInventory['local_secret_files'][number]>();
+  for (const file of files) {
+    const existing = byPath.get(file.path);
+    if (!existing) {
+      byPath.set(file.path, { path: file.path, key_names: file.key_names });
+    } else {
+      byPath.set(file.path, {
+        path: file.path,
+        key_names: Array.from(new Set([...existing.key_names, ...file.key_names])).sort(),
+      });
+    }
+  }
+  return Array.from(byPath.values()).sort((left, right) => left.path.localeCompare(right.path));
+}

--- a/openclaw-skills/src/security/supply-chain-guardrails.ts
+++ b/openclaw-skills/src/security/supply-chain-guardrails.ts
@@ -1,11 +1,18 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ActionType, RiskLevel, SupplyChainRisk } from '../types/protocol.js';
+import type { ActionType, AgentCommerceRisk, RiskLevel, SupplyChainRisk } from '../types/protocol.js';
 
 export interface SupplyChainRiskInput {
   actionType?: ActionType;
   command?: string;
   fileChanges?: string[];
+}
+
+export interface AgentCommerceRiskInput {
+  actionType?: ActionType;
+  command?: string;
+  estimatedMonthlyUsd?: number;
+  monthlyBudgetLimitUsd?: number;
 }
 
 export interface SecretExposureInventoryOptions {
@@ -112,6 +119,66 @@ const SUPPLY_CHAIN_PATTERNS: Array<{
   },
 ];
 
+const DEFAULT_AGENT_COMMERCE_MONTHLY_BUDGET_USD = 100;
+
+const AGENT_COMMERCE_PATTERNS: Array<{
+  pattern: RegExp;
+  category: AgentCommerceRisk['category'];
+  provider: AgentCommerceRisk['provider'];
+  severity: RiskLevel;
+  reason: string;
+}> = [
+  {
+    pattern: /\bstripe\s+projects\s+add\s+cloudflare\/registrar:domain\b/i,
+    category: 'domain_registration',
+    provider: 'stripe_projects',
+    severity: 'critical',
+    reason: 'Stripe Projects can register a Cloudflare domain and bill the signed-in user.',
+  },
+  {
+    pattern: /\bstripe\s+projects\s+add\s+cloudflare\/(?!registrar:domain\b)[^ \n]+/i,
+    category: 'paid_subscription',
+    provider: 'stripe_projects',
+    severity: 'critical',
+    reason: 'Stripe Projects can provision paid Cloudflare services using the user payment context.',
+  },
+  {
+    pattern: /\bstripe\s+projects\s+(deploy|provision|create|use)\b.*\bcloudflare\b/i,
+    category: 'cloud_account_provisioning',
+    provider: 'stripe_projects',
+    severity: 'critical',
+    reason: 'Agent-driven Cloudflare provisioning can create accounts, subscriptions, and deployable credentials.',
+  },
+  {
+    pattern: /(?:\bwrangler\b|\bcloudflare\s+).*\b(registrar|register|domain|zone)\b/i,
+    category: 'domain_registration',
+    provider: 'cloudflare',
+    severity: 'critical',
+    reason: 'Cloudflare domain and zone operations can create durable externally reachable infrastructure.',
+  },
+  {
+    pattern: /(?:\bwrangler\b|\bcloudflare\s+).*\b(account|subscription|billing|plan)\b/i,
+    category: 'paid_subscription',
+    provider: 'cloudflare',
+    severity: 'critical',
+    reason: 'Cloudflare account, subscription, and billing operations can create spend obligations.',
+  },
+  {
+    pattern: /(?:\bwrangler\b|\bcloudflare\s+).*\b(api[-_ ]?token|token|secret)\b/i,
+    category: 'api_token_minting',
+    provider: 'cloudflare',
+    severity: 'critical',
+    reason: 'Cloudflare token and secret operations can mint or expose deploy-capable credentials.',
+  },
+  {
+    pattern: /\bwrangler\s+(deploy|pages\s+deploy)\b/i,
+    category: 'deployment',
+    provider: 'cloudflare',
+    severity: 'high',
+    reason: 'Cloudflare deploy commands publish code to an externally reachable runtime.',
+  },
+];
+
 const SECRET_FILE_BASENAMES = new Set([
   '.env',
   '.env.local',
@@ -214,6 +281,75 @@ export function appendSupplyChainApprovalSummary(description: string, risk: Supp
     `Risk: ${risk.severity.toUpperCase()} (${risk.category})`,
     ...risk.reasons.map((reason) => `- ${reason}`),
     'Before approving, verify the package/source, expected credential access, and rollback/rotation plan.',
+  ].join('\n');
+}
+
+export function assessAgentCommerceRisk(input: AgentCommerceRiskInput): AgentCommerceRisk | null {
+  const command = input.command?.trim() ?? '';
+  if (!command && input.actionType !== 'deploy') return null;
+
+  const matches = AGENT_COMMERCE_PATTERNS.filter((entry) => command && entry.pattern.test(command));
+  if (input.actionType === 'deploy' && /\b(cloudflare|wrangler|workers?|pages)\b/i.test(command)) {
+    matches.push({
+      pattern: /.*/,
+      category: 'deployment',
+      provider: 'cloudflare',
+      severity: 'high',
+      reason: 'Cloudflare deployments publish code to production-like infrastructure.',
+    });
+  }
+
+  if (matches.length === 0) return null;
+
+  const categories = Array.from(new Set(matches.map((match) => match.category)));
+  const providers = Array.from(new Set(matches.map((match) => match.provider)));
+  const monthlyLimit = input.monthlyBudgetLimitUsd ?? DEFAULT_AGENT_COMMERCE_MONTHLY_BUDGET_USD;
+  const estimatedMonthlyUsd = normalizeUsd(input.estimatedMonthlyUsd) ?? extractUsdAmount(command);
+  const requiresBudgetConfirmation = estimatedMonthlyUsd === undefined;
+  const overBudget = estimatedMonthlyUsd !== undefined && estimatedMonthlyUsd > monthlyLimit;
+  const severity: RiskLevel = overBudget || matches.some((match) => match.severity === 'critical') ? 'critical' : 'high';
+
+  return {
+    detected: true,
+    category: categories.length === 1 ? categories[0]! : 'mixed',
+    provider: providers.length === 1 ? providers[0]! : 'unknown',
+    severity,
+    requires_explicit_approval: true,
+    reasons: Array.from(new Set([
+      ...matches.map((match) => match.reason),
+      overBudget
+        ? `Estimated monthly spend ${formatUsd(estimatedMonthlyUsd)} exceeds the configured ${formatUsd(monthlyLimit)} monthly approval budget.`
+        : null,
+      requiresBudgetConfirmation
+        ? `No monthly spend estimate was supplied; default approval budget is ${formatUsd(monthlyLimit)} per provider.`
+        : null,
+    ].filter((reason): reason is string => reason !== null))),
+    recommended_questions: recommendedAgentCommerceQuestions(categories, overBudget, requiresBudgetConfirmation),
+    budget: {
+      currency: 'USD',
+      monthly_limit_usd: monthlyLimit,
+      estimated_monthly_usd: estimatedMonthlyUsd ?? null,
+      over_budget: overBudget,
+      requires_budget_confirmation: requiresBudgetConfirmation,
+    },
+    artifacts: {
+      domains: extractDomains(command),
+      services: extractCloudflareServices(command),
+    },
+  };
+}
+
+export function appendAgentCommerceApprovalSummary(description: string, risk: AgentCommerceRisk | null): string {
+  if (!risk) return description;
+  return [
+    description,
+    '',
+    'Agent commerce guardrail:',
+    `Risk: ${risk.severity.toUpperCase()} (${risk.category})`,
+    `Provider: ${risk.provider}`,
+    `Budget: ${risk.budget.estimated_monthly_usd === null ? 'unestimated' : formatUsd(risk.budget.estimated_monthly_usd)} / ${formatUsd(risk.budget.monthly_limit_usd)} monthly limit`,
+    ...risk.reasons.map((reason) => `- ${reason}`),
+    'Before approving, verify ownership, billing cap, token scope, deployment target, and rollback/revoke plan.',
   ].join('\n');
 }
 
@@ -349,6 +485,28 @@ function recommendedRotations(categories: SupplyChainRisk['category'][]): string
   return Array.from(rotations);
 }
 
+function recommendedAgentCommerceQuestions(
+  categories: AgentCommerceRisk['category'][],
+  overBudget: boolean,
+  requiresBudgetConfirmation: boolean,
+): string[] {
+  const questions = [
+    'Which signed-in user, account, and payment method will own the provisioned Cloudflare resources?',
+    'What token scopes and expiration will be issued, and where will the token be stored?',
+    'What is the rollback plan: revoke token, cancel subscription, remove DNS/zone, or delete deployment?',
+  ];
+  if (categories.includes('domain_registration')) {
+    questions.unshift('What exact domain is being registered, what is the renewal cost, and who owns the registrant contact?');
+  }
+  if (categories.includes('paid_subscription') || overBudget || requiresBudgetConfirmation) {
+    questions.unshift('What monthly spend cap applies to this provider before the agent is allowed to continue?');
+  }
+  if (categories.includes('deployment')) {
+    questions.unshift('Which environment, route, and public hostname will receive the deployment?');
+  }
+  return Array.from(new Set(questions));
+}
+
 function isSecretBearingPath(filePath: string): boolean {
   const normalized = filePath.toLowerCase();
   const basename = path.basename(normalized);
@@ -366,6 +524,39 @@ function isPackageManifest(filePath: string): boolean {
   return PACKAGE_MANIFEST_BASENAMES.has(basename) ||
     filePath.includes('.github/dependabot.yml') ||
     filePath.includes('.github/dependabot.yaml');
+}
+
+function normalizeUsd(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return undefined;
+  return Math.round(value * 100) / 100;
+}
+
+function extractUsdAmount(command: string): number | undefined {
+  const amounts = [
+    ...Array.from(command.matchAll(/\$\s*(\d+(?:\.\d{1,2})?)/g)).map((match) => Number.parseFloat(match[1]!)),
+    ...Array.from(command.matchAll(/\bUSD\s*(\d+(?:\.\d{1,2})?)/gi)).map((match) => Number.parseFloat(match[1]!)),
+    ...Array.from(command.matchAll(/--(?:budget|max[-_]?spend|monthly[-_]?limit|spend[-_]?limit)(?:=|\s+)(\d+(?:\.\d{1,2})?)/gi)).map((match) => Number.parseFloat(match[1]!)),
+  ].filter((amount) => Number.isFinite(amount) && amount >= 0);
+  if (amounts.length === 0) return undefined;
+  return Math.max(...amounts);
+}
+
+function formatUsd(amount: number): string {
+  return `$${amount.toFixed(2)} USD`;
+}
+
+function extractDomains(command: string): string[] {
+  return Array.from(command.matchAll(/\b([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.(?:ai|app|build|cloud|co|com|dev|io|me|net|org|page|site|us|xyz))\b/gi))
+    .map((match) => match[1]!.toLowerCase())
+    .filter((domain, index, domains) => domains.indexOf(domain) === index)
+    .sort();
+}
+
+function extractCloudflareServices(command: string): string[] {
+  return Array.from(command.matchAll(/\b(cloudflare\/[a-z0-9:_-]+)\b/gi))
+    .map((match) => match[1]!.toLowerCase())
+    .filter((service, index, services) => services.indexOf(service) === index)
+    .sort();
 }
 
 function walk(rootDir: string, currentDir: string, onFile: (absolutePath: string, relativePath: string) => void): void {

--- a/openclaw-skills/src/skills/approval-gate.ts
+++ b/openclaw-skills/src/skills/approval-gate.ts
@@ -12,7 +12,9 @@ import type { IStateManager } from '../gateway/state-interface.js';
 import type { GatewayConfig } from '../config/default.js';
 import { evaluateApprovalPolicy } from '../gateway/policy.js';
 import {
+  appendAgentCommerceApprovalSummary,
   appendSupplyChainApprovalSummary,
+  assessAgentCommerceRisk,
   assessSupplyChainRisk,
 } from '../security/supply-chain-guardrails.js';
 
@@ -97,7 +99,17 @@ export class ApprovalGateSkill {
       command: options.command,
       fileChanges: options.context.git_operation?.file_changes,
     });
-    const riskLevel = supplyChainRisk?.severity === 'critical' ? 'critical' : options.context.riskLevel;
+    const agentCommerceRisk = assessAgentCommerceRisk({
+      actionType: options.actionType,
+      command: options.command,
+    });
+    const riskLevel = supplyChainRisk?.severity === 'critical' || agentCommerceRisk?.severity === 'critical'
+      ? 'critical'
+      : options.context.riskLevel;
+    const description = appendAgentCommerceApprovalSummary(
+      appendSupplyChainApprovalSummary(options.description, supplyChainRisk),
+      agentCommerceRisk,
+    );
 
     const request: ApprovalRequest = {
       id: uuidv4(),
@@ -105,7 +117,7 @@ export class ApprovalGateSkill {
       agent_name: options.agentName,
       action_type: options.actionType,
       title: options.title,
-      description: appendSupplyChainApprovalSummary(options.description, supplyChainRisk),
+      description,
       command: options.command,
       context: {
         service: options.context.service,
@@ -114,6 +126,7 @@ export class ApprovalGateSkill {
         risk_level: riskLevel,
         git_operation: options.context.git_operation,
         supply_chain: supplyChainRisk ?? undefined,
+        agent_commerce: agentCommerceRisk ?? undefined,
       },
       created_at: now.toISOString(),
       expires_at: expiresAt.toISOString(),
@@ -168,6 +181,7 @@ export class ApprovalGateSkill {
           policy_preset: policy.preset,
           policy_reason: policy.reason,
           supply_chain: request.context.supply_chain,
+          agent_commerce: request.context.agent_commerce,
         },
       });
       await this.storeRollbackPoint(request, options.rollback);

--- a/openclaw-skills/src/skills/approval-gate.ts
+++ b/openclaw-skills/src/skills/approval-gate.ts
@@ -11,6 +11,10 @@ import type { ApprovalRequest, ApprovalResponse, ActionType, RiskLevel, GitOpera
 import type { IStateManager } from '../gateway/state-interface.js';
 import type { GatewayConfig } from '../config/default.js';
 import { evaluateApprovalPolicy } from '../gateway/policy.js';
+import {
+  appendSupplyChainApprovalSummary,
+  assessSupplyChainRisk,
+} from '../security/supply-chain-guardrails.js';
 
 export interface DangerousActionOptions {
   agentId: string;
@@ -88,6 +92,12 @@ export class ApprovalGateSkill {
     const now = new Date();
     const timeoutMs = options.timeoutMs ?? this.config.approvalTimeoutMs;
     const expiresAt = new Date(now.getTime() + timeoutMs);
+    const supplyChainRisk = assessSupplyChainRisk({
+      actionType: options.actionType,
+      command: options.command,
+      fileChanges: options.context.git_operation?.file_changes,
+    });
+    const riskLevel = supplyChainRisk?.severity === 'critical' ? 'critical' : options.context.riskLevel;
 
     const request: ApprovalRequest = {
       id: uuidv4(),
@@ -95,14 +105,15 @@ export class ApprovalGateSkill {
       agent_name: options.agentName,
       action_type: options.actionType,
       title: options.title,
-      description: options.description,
+      description: appendSupplyChainApprovalSummary(options.description, supplyChainRisk),
       command: options.command,
       context: {
         service: options.context.service,
         environment: options.context.environment,
         repository: options.context.repository,
-        risk_level: options.context.riskLevel,
+        risk_level: riskLevel,
         git_operation: options.context.git_operation,
+        supply_chain: supplyChainRisk ?? undefined,
       },
       created_at: now.toISOString(),
       expires_at: expiresAt.toISOString(),
@@ -156,6 +167,7 @@ export class ApprovalGateSkill {
           command: request.command,
           policy_preset: policy.preset,
           policy_reason: policy.reason,
+          supply_chain: request.context.supply_chain,
         },
       });
       await this.storeRollbackPoint(request, options.rollback);

--- a/openclaw-skills/src/skills/incident-manager.ts
+++ b/openclaw-skills/src/skills/incident-manager.ts
@@ -8,6 +8,11 @@
 
 import type { Incident, IncidentSeverity, IncidentStatus, ActionType } from '../types/protocol.js';
 import type { IStateManager } from '../gateway/state-interface.js';
+import {
+  assessSupplyChainRisk,
+  buildSupplyChainIncidentRunbook,
+  type SecretExposureInventory,
+} from '../security/supply-chain-guardrails.js';
 
 export interface CreateIncidentOptions {
   agentId: string;
@@ -23,6 +28,15 @@ export interface ActionResult {
   action: ActionType;
   output: string;
   updatedAt: string;
+}
+
+export interface CreateSupplyChainIncidentOptions {
+  agentId: string;
+  agentName: string;
+  title: string;
+  command?: string;
+  repository?: string;
+  inventory?: SecretExposureInventory | null;
 }
 
 /**
@@ -43,6 +57,52 @@ export class IncidentManagerSkill {
       description: options.description,
       actions: options.actions ?? ['ask_root_cause', 'propose_fix', 'acknowledge'],
     });
+  }
+
+  /**
+   * Open a supply-chain incident with a rotation-first remediation runbook.
+   */
+  public async createSupplyChainIncident(options: CreateSupplyChainIncidentOptions): Promise<Incident> {
+    const risk = assessSupplyChainRisk({
+      actionType: 'shell_command',
+      command: options.command,
+    });
+    const description = buildSupplyChainIncidentRunbook({
+      title: options.title,
+      command: options.command,
+      risk,
+      inventory: options.inventory ?? null,
+    });
+
+    const incident = await this.state.createIncident({
+      agent_id: options.agentId,
+      agent_name: options.agentName,
+      severity: risk?.severity === 'critical' ? 'critical' : 'warning',
+      title: options.title,
+      description: [
+        description,
+        options.repository ? '' : null,
+        options.repository ? `Repository: ${options.repository}` : null,
+      ].filter((line): line is string => line !== null).join('\n'),
+      actions: ['ask_root_cause', 'key_rotation', 'acknowledge'],
+    });
+
+    await this.state.recordGovernanceEvent?.({
+      agent_id: options.agentId,
+      type: 'incident_state_changed',
+      title: options.title,
+      summary: 'Supply-chain incident opened with credential rotation workflow',
+      actor: 'gateway',
+      risk_level: incident.severity === 'critical' ? 'critical' : 'high',
+      incident_id: incident.id,
+      metadata: {
+        command: options.command,
+        repository: options.repository,
+        supply_chain: risk,
+        inventory_counts: options.inventory?.counts,
+      },
+    });
+    return incident;
   }
 
   /**
@@ -68,6 +128,9 @@ export class IncidentManagerSkill {
       case 'acknowledge':
         output = `Incident acknowledged. An engineer has been paged.`;
         newStatus = 'acknowledged';
+        break;
+      case 'key_rotation':
+        output = await this.planKeyRotation(incident);
         break;
       default:
         output = `Action "${action}" executed on incident "${incident.title}".`;
@@ -147,6 +210,20 @@ export class IncidentManagerSkill {
       ``,
       `Estimated resolution time: 15–30 minutes.`,
       `Rollback plan: \`kubectl rollout undo deployment/${incident.agent_name.toLowerCase().replace(/\s+/g, '-')}\``,
+    ].join('\n');
+  }
+
+  private async planKeyRotation(incident: Incident): Promise<string> {
+    await sleep(200);
+    return [
+      `Credential rotation plan for "${incident.title}":`,
+      ``,
+      `1. Inventory reachable credentials: local .env key names, shell environment key names, GitHub Actions secret names, package registry tokens, and cloud/app-store credentials.`,
+      `2. Revoke high-risk non-human identities first: GitHub, package registries, cloud providers, deployment platforms, billing, analytics, and AI provider API keys.`,
+      `3. Reissue least-privilege replacements and update .env plus GitHub Actions secrets with sanitized verification only.`,
+      `4. Re-run the failed or risky workflow from a clean dependency lockfile/container digest.`,
+      ``,
+      `Evidence required before resolution: secret names rotated, provider status response, and CI/deploy validation link.`,
     ].join('\n');
   }
 }

--- a/openclaw-skills/src/types/protocol.ts
+++ b/openclaw-skills/src/types/protocol.ts
@@ -176,6 +176,34 @@ export interface SupplyChainRisk {
   recommended_rotations: string[];
 }
 
+/** Agent commerce classification for account, paid service, domain, token, and deployment provisioning. */
+export interface AgentCommerceRisk {
+  detected: boolean;
+  category:
+    | 'cloud_account_provisioning'
+    | 'paid_subscription'
+    | 'domain_registration'
+    | 'api_token_minting'
+    | 'deployment'
+    | 'mixed';
+  provider: 'cloudflare' | 'stripe_projects' | 'unknown';
+  severity: RiskLevel;
+  requires_explicit_approval: boolean;
+  reasons: string[];
+  recommended_questions: string[];
+  budget: {
+    currency: 'USD';
+    monthly_limit_usd: number;
+    estimated_monthly_usd: number | null;
+    over_budget: boolean;
+    requires_budget_confirmation: boolean;
+  };
+  artifacts: {
+    domains: string[];
+    services: string[];
+  };
+}
+
 /** Context metadata for an approval request. */
 export interface ApprovalContext {
   service: string;
@@ -184,6 +212,7 @@ export interface ApprovalContext {
   risk_level: RiskLevel;
   git_operation?: GitOperation;
   supply_chain?: SupplyChainRisk;
+  agent_commerce?: AgentCommerceRisk;
 }
 
 /** An approval request pending human decision. */
@@ -253,6 +282,7 @@ export type GovernanceEventType =
   | 'agent_objective_updated'
   | 'agent_plan_step_upserted'
   | 'environment_observed'
+  | 'skill_workflow_registered'
   | 'rollback_point_added'
   | 'approval_requested'
   | 'approval_decided'
@@ -306,10 +336,84 @@ export interface ChatMessage {
 export interface BridgeSession {
   id: string;
   agent_id: string;
-  type: 'codex' | 'terminal' | 'other';
+  type: 'codex' | 'terminal' | 'background_agent' | 'other';
   title: string;
   cwd: string;
   closed: boolean;
+  created_at: string; // ISO8601
+  updated_at: string; // ISO8601
+  lifecycle?: 'starting' | 'running' | 'paused' | 'hibernated' | 'cancelling' | 'cancelled' | 'failed' | 'completed';
+  execution?: {
+    provider: 'vercel_open_agents' | 'cloudflare_agents' | 'local' | 'other';
+    workflow_id?: string;
+    sandbox_id?: string;
+    sandbox_state?: 'starting' | 'running' | 'paused' | 'hibernated' | 'stopped' | 'failed';
+    repository?: string;
+    branch?: string;
+    pull_request_url?: string;
+    dev_server_url?: string;
+    read_only_share_url?: string;
+  };
+  controls?: {
+    can_cancel: boolean;
+    can_pause: boolean;
+    can_resume: boolean;
+    can_hibernate: boolean;
+    can_share_readonly: boolean;
+  };
+  metadata: Record<string, unknown>;
+}
+
+// ─── Skill Workflow Systems ──────────────────────────────────────────────────
+
+export interface SkillWorkflowArtifact {
+  id: string;
+  label: string;
+  type: 'markdown' | 'html' | 'png' | 'json' | 'dashboard';
+  path?: string;
+  url?: string;
+}
+
+export interface SkillWorkflowCheckpoint {
+  id: string;
+  title: string;
+  after_step_id: string;
+  required: boolean;
+  approval_action_type?: ActionType;
+}
+
+export interface SkillWorkflowStep {
+  id: string;
+  order: number;
+  skill_name: string;
+  title: string;
+  input_requirements: string[];
+  consumes_from: string[];
+  output_contract: string[];
+  produces: string[];
+  human_checkpoint: boolean;
+  artifacts: SkillWorkflowArtifact[];
+}
+
+export interface SkillWorkflowValidation {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+  ordered_step_ids: string[];
+}
+
+export interface SkillWorkflowSystem {
+  id: string;
+  agent_id: string;
+  name: string;
+  description: string;
+  version: string;
+  trigger_prompt: string;
+  status: 'draft' | 'active' | 'archived';
+  steps: SkillWorkflowStep[];
+  checkpoints: SkillWorkflowCheckpoint[];
+  artifacts: SkillWorkflowArtifact[];
+  validation: SkillWorkflowValidation;
   created_at: string; // ISO8601
   updated_at: string; // ISO8601
   metadata: Record<string, unknown>;

--- a/openclaw-skills/src/types/protocol.ts
+++ b/openclaw-skills/src/types/protocol.ts
@@ -157,6 +157,25 @@ export interface GitOperation {
   diff_summary?: string;
 }
 
+/** Supply-chain/security classification for commands or repo changes. */
+export interface SupplyChainRisk {
+  detected: boolean;
+  category:
+    | 'dependency_install'
+    | 'container_image'
+    | 'remote_script'
+    | 'cli_install'
+    | 'credential_command'
+    | 'secret_touch'
+    | 'agent_tooling'
+    | 'mixed';
+  severity: RiskLevel;
+  requires_explicit_approval: boolean;
+  reasons: string[];
+  recommended_questions: string[];
+  recommended_rotations: string[];
+}
+
 /** Context metadata for an approval request. */
 export interface ApprovalContext {
   service: string;
@@ -164,6 +183,7 @@ export interface ApprovalContext {
   repository: string;
   risk_level: RiskLevel;
   git_operation?: GitOperation;
+  supply_chain?: SupplyChainRisk;
 }
 
 /** An approval request pending human decision. */

--- a/openclaw-skills/tests/approval-gate-policy.test.ts
+++ b/openclaw-skills/tests/approval-gate-policy.test.ts
@@ -212,4 +212,45 @@ describe('ApprovalGateSkill policy presets', () => {
     expect(governance.events.map((event) => event.type)).toContain('approval_decided');
     expect(governance.events.map((event) => event.type)).toContain('rollback_point_added');
   });
+
+  test('agent commerce commands are enriched and require explicit approval under yolo presets', async () => {
+    const state = new StateManager();
+    await state.upsertAgent(makeAgent());
+    const gate = new ApprovalGateSkill(state, {
+      ...DEFAULT_CONFIG,
+      approvalPolicyPreset: 'danger-yolo',
+    });
+
+    const promise = gate.requestApproval({
+      agentId: 'agent-policy',
+      agentName: 'Policy Agent',
+      actionType: 'shell_command',
+      title: 'Register domain',
+      description: 'Provision Cloudflare resources through Stripe Projects',
+      command: 'stripe projects add cloudflare/registrar:domain openclaw.dev',
+      timeoutMs: 10_000,
+      context: {
+        service: 'cloudflare',
+        environment: 'production',
+        repository: 'IgorGanapolsky/openclaw-console',
+        riskLevel: 'high',
+      },
+    });
+
+    const pending = state.listPendingApprovals();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.context.risk_level).toBe('critical');
+    expect(pending[0]?.context.agent_commerce?.category).toBe('domain_registration');
+    expect(pending[0]?.context.agent_commerce?.budget.requires_budget_confirmation).toBe(true);
+    expect(pending[0]?.description).toContain('Agent commerce guardrail');
+    state.respondToApproval({
+      approval_id: pending[0]!.id,
+      decision: 'denied',
+      biometric_verified: true,
+      responded_at: new Date().toISOString(),
+    });
+
+    const result = await promise;
+    expect(result.approved).toBe(false);
+  });
 });

--- a/openclaw-skills/tests/approval-gate-policy.test.ts
+++ b/openclaw-skills/tests/approval-gate-policy.test.ts
@@ -86,6 +86,88 @@ describe('ApprovalGateSkill policy presets', () => {
     expect(gate.getDecisionLog()[0]?.autoApproved).toBe(false);
   });
 
+  test('supply-chain commands are enriched and require explicit approval under yolo presets', async () => {
+    const state = new StateManager();
+    await state.upsertAgent(makeAgent());
+    const gate = new ApprovalGateSkill(state, {
+      ...DEFAULT_CONFIG,
+      approvalPolicyPreset: 'danger-yolo',
+    });
+
+    const promise = gate.requestApproval({
+      agentId: 'agent-policy',
+      agentName: 'Policy Agent',
+      actionType: 'shell_command',
+      title: 'Install package',
+      description: 'Install a new package for the agent runtime',
+      command: 'npm install suspicious-package',
+      timeoutMs: 10_000,
+      context: {
+        service: 'repo',
+        environment: 'development',
+        repository: 'IgorGanapolsky/openclaw-console',
+        riskLevel: 'high',
+      },
+    });
+
+    const pending = state.listPendingApprovals();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.context.risk_level).toBe('critical');
+    expect(pending[0]?.context.supply_chain?.category).toBe('dependency_install');
+    expect(pending[0]?.description).toContain('Supply-chain guardrail');
+    state.respondToApproval({
+      approval_id: pending[0]!.id,
+      decision: 'denied',
+      biometric_verified: true,
+      responded_at: new Date().toISOString(),
+    });
+
+    const result = await promise;
+    expect(result.approved).toBe(false);
+  });
+
+  test('secret-bearing file changes mark git commits as critical', async () => {
+    const state = new StateManager();
+    await state.upsertAgent(makeAgent());
+    const gate = new ApprovalGateSkill(state, {
+      ...DEFAULT_CONFIG,
+      approvalPolicyPreset: 'repo-yolo',
+    });
+
+    const promise = gate.requestApproval({
+      agentId: 'agent-policy',
+      agentName: 'Policy Agent',
+      actionType: 'git_commit',
+      title: 'Commit env config',
+      description: 'Commit environment config changes',
+      command: 'git commit -m "update env"',
+      timeoutMs: 10_000,
+      context: {
+        service: 'git',
+        environment: 'development',
+        repository: 'IgorGanapolsky/openclaw-console',
+        riskLevel: 'high',
+        git_operation: {
+          operation_type: 'commit',
+          file_changes: ['.env.production'],
+          diff_summary: '+2 -0',
+        },
+      },
+    });
+
+    const pending = state.listPendingApprovals();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.context.supply_chain?.category).toBe('secret_touch');
+    state.respondToApproval({
+      approval_id: pending[0]!.id,
+      decision: 'denied',
+      biometric_verified: true,
+      responded_at: new Date().toISOString(),
+    });
+
+    await promise;
+  });
+
   test('approved dangerous action records rollback point and audit events', async () => {
     const state = new StateManager();
     await state.upsertAgent(makeAgent());

--- a/openclaw-skills/tests/policy.test.ts
+++ b/openclaw-skills/tests/policy.test.ts
@@ -91,4 +91,37 @@ describe('approval policy presets', () => {
     expect(decision.autoApproved).toBe(false);
     expect(decision.reason).toContain('supply-chain');
   });
+
+  test('danger-yolo blocks agent commerce provisioning', () => {
+    const decision = evaluateApprovalPolicy('danger-yolo', {
+      actionType: 'shell_command',
+      command: 'stripe projects add cloudflare/registrar:domain openclaw.dev',
+      context: {
+        ...baseContext,
+        agent_commerce: {
+          detected: true,
+          category: 'domain_registration',
+          provider: 'stripe_projects',
+          severity: 'critical',
+          requires_explicit_approval: true,
+          reasons: ['Registers and bills a domain.'],
+          recommended_questions: [],
+          budget: {
+            currency: 'USD',
+            monthly_limit_usd: 100,
+            estimated_monthly_usd: null,
+            over_budget: false,
+            requires_budget_confirmation: true,
+          },
+          artifacts: {
+            domains: ['openclaw.dev'],
+            services: ['cloudflare/registrar:domain'],
+          },
+        },
+      },
+    });
+
+    expect(decision.autoApproved).toBe(false);
+    expect(decision.reason).toContain('agent commerce');
+  });
 });

--- a/openclaw-skills/tests/policy.test.ts
+++ b/openclaw-skills/tests/policy.test.ts
@@ -69,4 +69,26 @@ describe('approval policy presets', () => {
     expect(decision.autoApproved).toBe(false);
     expect(decision.reason).toContain('never');
   });
+
+  test('repo-yolo blocks supply-chain commands even when they are repository operations', () => {
+    const decision = evaluateApprovalPolicy('repo-yolo', {
+      actionType: 'shell_command',
+      command: 'npm install left-pad',
+      context: {
+        ...baseContext,
+        supply_chain: {
+          detected: true,
+          category: 'dependency_install',
+          severity: 'critical',
+          requires_explicit_approval: true,
+          reasons: ['Package install can execute lifecycle scripts.'],
+          recommended_questions: [],
+          recommended_rotations: [],
+        },
+      },
+    });
+
+    expect(decision.autoApproved).toBe(false);
+    expect(decision.reason).toContain('supply-chain');
+  });
 });

--- a/openclaw-skills/tests/project-session.test.ts
+++ b/openclaw-skills/tests/project-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { normalizeProjectBridgeSession } from '../src/gateway/project-session.js';
+import { applyBridgeSessionControl, normalizeProjectBridgeSession } from '../src/gateway/project-session.js';
 import type { BridgeSession } from '../src/types/protocol.js';
 
 function bridge(overrides: Partial<BridgeSession> = {}): BridgeSession {
@@ -36,5 +36,35 @@ describe('project-scoped bridge sessions', () => {
 
     expect(repoA.id).not.toBe(repoB.id);
     expect(repoB.metadata['project_name']).toBe('repo-b');
+  });
+
+  test('tracks background agent lifecycle controls', () => {
+    const session = normalizeProjectBridgeSession(bridge({
+      type: 'background_agent',
+      execution: {
+        provider: 'vercel_open_agents',
+        workflow_id: 'wf_123',
+        sandbox_id: 'sbx_123',
+        sandbox_state: 'running',
+        repository: 'IgorGanapolsky/openclaw-console',
+        branch: 'feat/background-agent',
+      },
+    }));
+
+    const paused = applyBridgeSessionControl(session, 'pause', { actor: 'human' });
+    expect(paused.lifecycle).toBe('paused');
+    expect(paused.execution?.sandbox_state).toBe('paused');
+    expect(paused.controls?.can_resume).toBe(true);
+
+    const shared = applyBridgeSessionControl(paused, 'share_readonly', {
+      actor: 'human',
+      readOnlyShareUrl: 'https://example.com/share/session',
+    });
+    expect(shared.execution?.read_only_share_url).toBe('https://example.com/share/session');
+
+    const cancelled = applyBridgeSessionControl(shared, 'cancel', { actor: 'human' });
+    expect(cancelled.closed).toBe(true);
+    expect(cancelled.lifecycle).toBe('cancelled');
+    expect(cancelled.controls?.can_cancel).toBe(false);
   });
 });

--- a/openclaw-skills/tests/runtime-config.test.ts
+++ b/openclaw-skills/tests/runtime-config.test.ts
@@ -149,4 +149,36 @@ describe('runtime config API', () => {
 
     fs.rmSync(config.tokenStorePath, { force: true });
   });
+
+  test('exposes supply-chain assessment and secret inventory APIs', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-security-api-'));
+    fs.writeFileSync(path.join(root, '.env'), 'STRIPE_SECRET_KEY=sk-live-hidden\n', 'utf8');
+    const config = tempConfig();
+    const { baseUrl, token } = await start(config);
+
+    const assessResponse = await fetch(`${baseUrl}/api/security/supply-chain/assess`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ command: 'docker run --rm untrusted/image:latest' }),
+    });
+
+    expect(assessResponse.status).toBe(200);
+    const assessBody = await assessResponse.json() as Record<string, unknown>;
+    expect(assessBody['detected']).toBe(true);
+
+    const inventoryResponse = await fetch(`${baseUrl}/api/security/secret-inventory?root=${encodeURIComponent(root)}`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(inventoryResponse.status).toBe(200);
+    const inventoryBody = await inventoryResponse.json() as Record<string, unknown>;
+    expect(JSON.stringify(inventoryBody)).toContain('STRIPE_SECRET_KEY');
+    expect(JSON.stringify(inventoryBody)).not.toContain('sk-live-hidden');
+
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(config.tokenStorePath, { force: true });
+  });
 });

--- a/openclaw-skills/tests/runtime-config.test.ts
+++ b/openclaw-skills/tests/runtime-config.test.ts
@@ -151,8 +151,7 @@ describe('runtime config API', () => {
   });
 
   test('exposes supply-chain assessment and secret inventory APIs', async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-security-api-'));
-    fs.writeFileSync(path.join(root, '.env'), 'STRIPE_SECRET_KEY=sk-live-hidden\n', 'utf8');
+    process.env['OPENCLAW_TEST_SECRET_KEY'] = 'hidden-runtime-test-value';
     const config = tempConfig();
     const { baseUrl, token } = await start(config);
 
@@ -169,16 +168,16 @@ describe('runtime config API', () => {
     const assessBody = await assessResponse.json() as Record<string, unknown>;
     expect(assessBody['detected']).toBe(true);
 
-    const inventoryResponse = await fetch(`${baseUrl}/api/security/secret-inventory?root=${encodeURIComponent(root)}`, {
+    const inventoryResponse = await fetch(`${baseUrl}/api/security/secret-inventory`, {
       headers: { authorization: `Bearer ${token}` },
     });
 
     expect(inventoryResponse.status).toBe(200);
     const inventoryBody = await inventoryResponse.json() as Record<string, unknown>;
-    expect(JSON.stringify(inventoryBody)).toContain('STRIPE_SECRET_KEY');
-    expect(JSON.stringify(inventoryBody)).not.toContain('sk-live-hidden');
+    expect(JSON.stringify(inventoryBody)).toContain('OPENCLAW_TEST_SECRET_KEY');
+    expect(JSON.stringify(inventoryBody)).not.toContain('hidden-runtime-test-value');
 
-    fs.rmSync(root, { recursive: true, force: true });
+    delete process.env['OPENCLAW_TEST_SECRET_KEY'];
     fs.rmSync(config.tokenStorePath, { force: true });
   });
 });

--- a/openclaw-skills/tests/runtime-config.test.ts
+++ b/openclaw-skills/tests/runtime-config.test.ts
@@ -168,6 +168,24 @@ describe('runtime config API', () => {
     const assessBody = await assessResponse.json() as Record<string, unknown>;
     expect(assessBody['detected']).toBe(true);
 
+    const commerceResponse = await fetch(`${baseUrl}/api/security/agent-commerce/assess`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        command: 'stripe projects add cloudflare/registrar:domain openclaw.dev',
+        estimated_monthly_usd: 12,
+        monthly_budget_limit_usd: 10,
+      }),
+    });
+
+    expect(commerceResponse.status).toBe(200);
+    const commerceBody = await commerceResponse.json() as Record<string, unknown>;
+    expect(commerceBody['detected']).toBe(true);
+    expect(JSON.stringify(commerceBody)).toContain('domain_registration');
+
     const inventoryResponse = await fetch(`${baseUrl}/api/security/secret-inventory`, {
       headers: { authorization: `Bearer ${token}` },
     });
@@ -178,6 +196,79 @@ describe('runtime config API', () => {
     expect(JSON.stringify(inventoryBody)).not.toContain('hidden-runtime-test-value');
 
     delete process.env['OPENCLAW_TEST_SECRET_KEY'];
+    fs.rmSync(config.tokenStorePath, { force: true });
+  });
+
+  test('registers skill workflow systems for orchestrator skills', async () => {
+    const config = tempConfig();
+    const state = new StateManager();
+    await state.upsertAgent({
+      id: 'agent-skill-workflow',
+      name: 'Skill Workflow Agent',
+      description: 'Test agent',
+      status: 'online',
+      workspace: 'test',
+      tags: ['test'],
+      last_active: new Date().toISOString(),
+      active_tasks: 0,
+      pending_approvals: 0,
+    });
+    const { baseUrl, token } = await start(config, state);
+
+    const response = await fetch(`${baseUrl}/api/skill-workflows/upsert`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        agent_id: 'agent-skill-workflow',
+        name: 'Research orchestrator',
+        trigger_prompt: 'Research and implement high-ROI items',
+        steps: [
+          {
+            skill_name: 'source-reader',
+            input_requirements: ['url'],
+            output_contract: ['verified source notes'],
+            produces: ['source_notes'],
+          },
+          {
+            skill_name: 'implementation-planner',
+            consumes_from: ['source_notes'],
+            input_requirements: ['source_notes'],
+            output_contract: ['ranked implementation plan'],
+            produces: ['implementation_plan'],
+          },
+        ],
+        checkpoints: [
+          {
+            title: 'Approve implementation plan',
+            after_step_id: 'step-2',
+            required: true,
+          },
+        ],
+        artifacts: [
+          {
+            label: 'Plan markdown',
+            type: 'markdown',
+            path: 'docs/plan.md',
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as Record<string, unknown>;
+    expect(JSON.stringify(body)).toContain('Research orchestrator');
+    expect(JSON.stringify(body)).toContain('ordered_step_ids');
+
+    const listResponse = await fetch(`${baseUrl}/api/skill-workflows?agent_id=agent-skill-workflow`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(listResponse.status).toBe(200);
+    const listBody = await listResponse.json() as unknown[];
+    expect(listBody).toHaveLength(1);
+
     fs.rmSync(config.tokenStorePath, { force: true });
   });
 });

--- a/openclaw-skills/tests/skill-workflow.test.ts
+++ b/openclaw-skills/tests/skill-workflow.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  normalizeSkillWorkflowSystem,
+  validateSkillWorkflowSystem,
+} from '../src/gateway/skill-workflow.js';
+
+describe('skill workflow systems', () => {
+  test('normalizes a modular orchestrator workflow with handoffs and checkpoints', () => {
+    const workflow = normalizeSkillWorkflowSystem({
+      agent_id: 'agent-skill-system',
+      name: 'Video-to-brief orchestrator',
+      trigger_prompt: 'Create a strategic brief from a video URL',
+      steps: [
+        {
+          skill_name: 'transcript-extractor',
+          input_requirements: ['video_url'],
+          output_contract: ['clean transcript markdown'],
+          produces: ['transcript_md'],
+        },
+        {
+          skill_name: 'strategy-synthesizer',
+          consumes_from: ['transcript_md'],
+          input_requirements: ['transcript_md', 'business_goal'],
+          output_contract: ['ranked high-ROI item list'],
+          produces: ['roi_items'],
+          human_checkpoint: true,
+        },
+      ],
+      checkpoints: [
+        {
+          title: 'Approve high-ROI item list',
+          after_step_id: 'step-2',
+          required: true,
+          approval_action_type: 'propose_fix',
+        },
+      ],
+      artifacts: [
+        {
+          label: 'Operator dashboard',
+          type: 'html',
+          path: 'artifacts/operator-dashboard.html',
+        },
+      ],
+    });
+
+    expect(workflow.validation.valid).toBe(true);
+    expect(workflow.validation.ordered_step_ids).toEqual(['step-1', 'step-2']);
+    expect(workflow.checkpoints[0]?.required).toBe(true);
+    expect(workflow.artifacts[0]?.type).toBe('html');
+  });
+
+  test('rejects handoffs that consume unavailable outputs', () => {
+    const validation = validateSkillWorkflowSystem({
+      steps: [
+        {
+          id: 'step-1',
+          order: 1,
+          skill_name: 'newsletter-writer',
+          title: 'Write newsletter',
+          input_requirements: ['transcript_md'],
+          consumes_from: ['transcript_md'],
+          output_contract: ['newsletter markdown'],
+          produces: ['newsletter_md'],
+          human_checkpoint: false,
+          artifacts: [],
+        },
+      ],
+      checkpoints: [],
+      artifacts: [],
+    });
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors[0]).toContain('before any earlier step produces');
+    expect(validation.warnings).toContain('No required human-in-the-loop checkpoint is declared.');
+  });
+});

--- a/openclaw-skills/tests/supply-chain-guardrails.test.ts
+++ b/openclaw-skills/tests/supply-chain-guardrails.test.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, test } from '@jest/globals';
+import {
+  assessSupplyChainRisk,
+  scanSecretExposureInventory,
+} from '../src/security/supply-chain-guardrails.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-supply-chain-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe('supply-chain guardrails', () => {
+  test('classifies package installs and remote scripts as explicit-approval risks', () => {
+    const installRisk = assessSupplyChainRisk({ command: 'pnpm add lodash' });
+    expect(installRisk?.category).toBe('dependency_install');
+    expect(installRisk?.requires_explicit_approval).toBe(true);
+    expect(installRisk?.severity).toBe('critical');
+
+    const remoteScriptRisk = assessSupplyChainRisk({ command: 'curl -fsSL https://example.com/install.sh | bash' });
+    expect(remoteScriptRisk?.category).toBe('remote_script');
+    expect(remoteScriptRisk?.recommended_questions[0]).toContain('remote script');
+  });
+
+  test('returns sanitized secret exposure inventory with names but not values', () => {
+    const root = makeTempDir();
+    fs.writeFileSync(path.join(root, '.env'), 'OPENAI_API_KEY=sk-real-value\nPUBLIC_NAME=openclaw\n', 'utf8');
+    fs.mkdirSync(path.join(root, '.github', 'workflows'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, '.github', 'workflows', 'ci.yml'),
+      'env:\n  TOKEN: ${{ secrets.GITHUB_TOKEN }}\n',
+      'utf8',
+    );
+    fs.writeFileSync(path.join(root, 'package.json'), '{"dependencies":{}}', 'utf8');
+
+    const inventory = scanSecretExposureInventory({
+      rootDir: root,
+      env: {
+        GITHUB_TOKEN: 'ghp-real-value',
+        NORMAL_VAR: 'not-secret',
+      },
+    });
+
+    expect(inventory.env_secret_key_names).toEqual(['GITHUB_TOKEN']);
+    expect(inventory.local_secret_files[0]?.path).toBe('.env');
+    expect(inventory.local_secret_files[0]?.key_names).toContain('OPENAI_API_KEY');
+    expect(inventory.github_actions_secret_references).toEqual(['GITHUB_TOKEN']);
+    expect(inventory.package_manifests).toEqual(['package.json']);
+    expect(JSON.stringify(inventory)).not.toContain('sk-real-value');
+    expect(JSON.stringify(inventory)).not.toContain('ghp-real-value');
+  });
+});

--- a/openclaw-skills/tests/supply-chain-guardrails.test.ts
+++ b/openclaw-skills/tests/supply-chain-guardrails.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, test } from '@jest/globals';
 import {
+  assessAgentCommerceRisk,
   assessSupplyChainRisk,
   scanSecretExposureInventory,
 } from '../src/security/supply-chain-guardrails.js';
@@ -31,6 +32,21 @@ describe('supply-chain guardrails', () => {
     const remoteScriptRisk = assessSupplyChainRisk({ command: 'curl -fsSL https://example.com/install.sh | bash' });
     expect(remoteScriptRisk?.category).toBe('remote_script');
     expect(remoteScriptRisk?.recommended_questions[0]).toContain('remote script');
+  });
+
+  test('classifies Cloudflare agent commerce with budget context', () => {
+    const risk = assessAgentCommerceRisk({
+      command: 'stripe projects add cloudflare/registrar:domain openclaw.dev --monthly-limit 25',
+      estimatedMonthlyUsd: 12,
+      monthlyBudgetLimitUsd: 10,
+    });
+
+    expect(risk?.category).toBe('domain_registration');
+    expect(risk?.provider).toBe('stripe_projects');
+    expect(risk?.requires_explicit_approval).toBe(true);
+    expect(risk?.budget.over_budget).toBe(true);
+    expect(risk?.artifacts.domains).toEqual(['openclaw.dev']);
+    expect(risk?.artifacts.services).toEqual(['cloudflare/registrar:domain']);
   });
 
   test('returns sanitized secret exposure inventory with names but not values', () => {


### PR DESCRIPTION
## Summary
- add gateway supply-chain risk classification for dependency installs, remote scripts, container commands, credential commands, secret-file access, and agent tooling changes
- enrich approval requests with supply-chain context and block yolo auto-approval for those risks
- add sanitized secret inventory and supply-chain incident APIs with credential-rotation guidance
- document the protocol, architecture, and DAA positioning

## Validation
- npm run build
- npm run lint
- npm test -- --runInBand
- pre-commit hook: passed
- pre-push hook: release contract passed with 3 screenshot/version warnings; Android guardrails passed with SDK fallback; Android unit tests + assembleDebug passed; skills tests passed

## Notes
- Local iOS build was skipped by the pre-push hook because Swift packages are not resolved in ios/OpenClawConsole/.build/DerivedData/SourcePackages/checkouts; CI remains authoritative for iOS verification.
- Secret inventory reports key names and paths only, never values.