### PR TITLE
fix: verify internal TestFlight users correctly

### DIFF
--- a/scripts/ensure_testflight_visibility.py
+++ b/scripts/ensure_testflight_visibility.py
@@ -21,6 +21,12 @@ INTERNAL_PSEUDO_GROUPS = {
     "appstore connect users",
     "asc users",
 }
+INTERNAL_TESTER_ROLES = {
+    "ADMIN",
+    "APP_MANAGER",
+    "DEVELOPER",
+    "MARKETING",
+}
 
 
 def csv(raw: str) -> list[str]:
@@ -188,6 +194,23 @@ class TestFlightVisibility:
         testers = payload.get("data", [])
         return testers[0] if testers else None
 
+    def app_store_user(self, email: str) -> dict[str, Any] | None:
+        payload = self.client.request(
+            "GET",
+            "/users",
+            params={
+                "filter[email]": email,
+                "fields[users]": "email,roles,allAppsVisible",
+                "limit": "1",
+            },
+        )
+        users = payload.get("data", [])
+        return users[0] if users else None
+
+    def user_visible_app_ids(self, user_id: str) -> set[str]:
+        apps = self.client.get_all(f"/users/{user_id}/visibleApps", params={"limit": "200"})
+        return {app["id"] for app in apps}
+
     def beta_tester_build_ids(self, tester_id: str) -> set[str]:
         builds = self.client.get_all(f"/betaTesters/{tester_id}/relationships/builds", params={"limit": "200"})
         return {build["id"] for build in builds}
@@ -269,35 +292,38 @@ class TestFlightVisibility:
 
         if groups and all(is_internal_pseudo_group(name) for name in groups):
             missing: list[str] = []
-            missing_build_access: list[str] = []
+            ineligible: list[str] = []
+            missing_app_access: list[str] = []
             for email in required_testers:
                 normalized_email = email.lower()
-                tester = self.beta_tester(normalized_email)
-                if not tester:
+                user = self.app_store_user(normalized_email)
+                if not user:
                     missing.append(normalized_email)
                     continue
 
-                tester_id = tester["id"]
-                if build_id in self.beta_tester_build_ids(tester_id):
+                attrs = user.get("attributes", {})
+                roles = set(attrs.get("roles") or [])
+                if not roles.intersection(INTERNAL_TESTER_ROLES):
+                    ineligible.append(f"{normalized_email} roles={sorted(roles)}")
                     continue
 
-                if assign_required_testers:
-                    self.attach_beta_tester_build(tester_id, build_id)
-                    if build_id in self.beta_tester_build_ids(tester_id):
-                        assigned_required_testers.append(normalized_email)
-                        continue
-
-                missing_build_access.append(normalized_email)
+                if not bool(attrs.get("allAppsVisible")) and app_id not in self.user_visible_app_ids(user["id"]):
+                    missing_app_access.append(normalized_email)
 
             if missing:
                 raise RuntimeError(
-                    "Required internal TestFlight testers missing from App Store Connect beta testers: "
+                    "Required internal TestFlight testers missing from App Store Connect users: "
                     + ", ".join(missing)
                 )
-            if missing_build_access:
+            if ineligible:
                 raise RuntimeError(
-                    "Required internal TestFlight testers are not assigned to build "
-                    f"{version} ({build_number}): " + ", ".join(missing_build_access)
+                    "Required internal TestFlight testers do not have an internal testing role: "
+                    + "; ".join(ineligible)
+                )
+            if missing_app_access:
+                raise RuntimeError(
+                    "Required internal TestFlight testers do not have access to app "
+                    f"{self.bundle_id}: " + ", ".join(missing_app_access)
                 )
 
         if missing_testers:

--- a/scripts/tests/test_ensure_testflight_visibility.py
+++ b/scripts/tests/test_ensure_testflight_visibility.py
@@ -8,9 +8,22 @@ from scripts.ensure_testflight_visibility import TestFlightVisibility, is_intern
 
 
 class FakeClient:
-    def __init__(self, *, tester_exists: bool = True, tester_has_build: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        tester_exists: bool = True,
+        tester_has_build: bool = True,
+        user_exists: bool = True,
+        user_roles: list[str] | None = None,
+        all_apps_visible: bool = True,
+        visible_app_ids: set[str] | None = None,
+    ) -> None:
         self.tester_exists = tester_exists
         self.tester_has_build = tester_has_build
+        self.user_exists = user_exists
+        self.user_roles = user_roles or ["ADMIN"]
+        self.all_apps_visible = all_apps_visible
+        self.visible_app_ids = visible_app_ids if visible_app_ids is not None else {"app-1"}
         self.group_requests = 0
         self.assigned_builds: list[tuple[str, str]] = []
 
@@ -35,6 +48,21 @@ class FakeClient:
                 self.assigned_builds.append(("tester-1", payload["data"][0]["id"]))
                 self.tester_has_build = True
                 return {}
+        if path == "/users":
+            return {
+                "data": [
+                    {
+                        "id": "user-1",
+                        "attributes": {
+                            "email": "iganapolsky@gmail.com",
+                            "roles": self.user_roles,
+                            "allAppsVisible": self.all_apps_visible,
+                        },
+                    }
+                ]
+                if self.user_exists
+                else []
+            }
         raise AssertionError(f"unexpected request: {method} {path}")
 
     def get_all(self, path, *, params=None):
@@ -43,6 +71,8 @@ class FakeClient:
             return []
         if path == "/betaTesters/tester-1/relationships/builds":
             return [{"id": "build-1"}] if self.tester_has_build else []
+        if path == "/users/user-1/visibleApps":
+            return [{"id": app_id} for app_id in sorted(self.visible_app_ids)]
         raise AssertionError(f"unexpected get_all: {path}")
 
 
@@ -52,8 +82,8 @@ class TestInternalPseudoGroups(unittest.TestCase):
         self.assertTrue(is_internal_pseudo_group("  appstore   connect users "))
         self.assertFalse(is_internal_pseudo_group("Internal Testers"))
 
-    def test_pseudo_group_checks_build_and_required_tester_without_beta_group(self) -> None:
-        client = FakeClient(tester_exists=True)
+    def test_pseudo_group_checks_build_and_required_asc_user_without_beta_group(self) -> None:
+        client = FakeClient(user_exists=True)
         result = TestFlightVisibility(client, "com.openclaw.console").ensure(
             "1.0.0",
             ["App Store Connect Users"],
@@ -67,25 +97,34 @@ class TestInternalPseudoGroups(unittest.TestCase):
         self.assertEqual(client.group_requests, 0)
 
     def test_pseudo_group_fails_when_required_tester_is_missing(self) -> None:
-        client = FakeClient(tester_exists=False)
-        with self.assertRaisesRegex(RuntimeError, "Required internal TestFlight testers missing"):
+        client = FakeClient(user_exists=False)
+        with self.assertRaisesRegex(RuntimeError, "missing from App Store Connect users"):
             TestFlightVisibility(client, "com.openclaw.console").ensure(
                 "1.0.0",
                 ["App Store Connect Users"],
                 ["iganapolsky@gmail.com"],
             )
 
-    def test_pseudo_group_fails_when_required_tester_lacks_build_access(self) -> None:
-        client = FakeClient(tester_exists=True, tester_has_build=False)
-        with self.assertRaisesRegex(RuntimeError, "not assigned to build"):
+    def test_pseudo_group_fails_when_required_user_lacks_internal_tester_role(self) -> None:
+        client = FakeClient(user_exists=True, user_roles=["CUSTOMER_SUPPORT"])
+        with self.assertRaisesRegex(RuntimeError, "do not have an internal testing role"):
             TestFlightVisibility(client, "com.openclaw.console").ensure(
                 "1.0.0",
                 ["App Store Connect Users"],
                 ["iganapolsky@gmail.com"],
             )
 
-    def test_pseudo_group_assigns_required_tester_to_build_when_requested(self) -> None:
-        client = FakeClient(tester_exists=True, tester_has_build=False)
+    def test_pseudo_group_fails_when_required_user_lacks_app_access(self) -> None:
+        client = FakeClient(user_exists=True, all_apps_visible=False, visible_app_ids={"other-app"})
+        with self.assertRaisesRegex(RuntimeError, "do not have access to app"):
+            TestFlightVisibility(client, "com.openclaw.console").ensure(
+                "1.0.0",
+                ["App Store Connect Users"],
+                ["iganapolsky@gmail.com"],
+            )
+
+    def test_pseudo_group_passes_when_required_user_has_specific_app_access(self) -> None:
+        client = FakeClient(user_exists=True, all_apps_visible=False, visible_app_ids={"app-1"})
         result = TestFlightVisibility(client, "com.openclaw.console").ensure(
             "1.0.0",
             ["App Store Connect Users"],
@@ -93,8 +132,8 @@ class TestInternalPseudoGroups(unittest.TestCase):
             assign_required_testers=True,
         )
         self.assertEqual(result["status"], "VISIBLE")
-        self.assertEqual(result["required_testers_assigned"], 1)
-        self.assertEqual(client.assigned_builds, [("tester-1", "build-1")])
+        self.assertEqual(result["required_testers_assigned"], 0)
+        self.assertEqual(client.assigned_builds, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- verify App Store Connect user eligibility for the built-in App Store Connect Users TestFlight group
- keep real beta group checks unchanged
- update TestFlight visibility verifier unit coverage

## Evidence
- python3 -m unittest scripts.tests.test_ensure_testflight_visibility: 6 tests OK
- python3 scripts/validate_release_contract.py: passed with existing screenshot warnings
- pre-push hook: Android unit tests + assembleDebug passed; skills tests 106 passed