### PR TITLE
Persist CTO session directives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,11 +93,25 @@ Mobile apps are thin clients. All intelligence lives in OpenClaw skills on the u
 
 ## Session Directive: PR Management & System Hygiene
 
+### Session Start Protocol
+1. Read `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`.
+2. Query local RAG/memory for relevant lessons before planning.
+3. Review open PRs, branches, worktrees, and CI status.
+4. Exclude secrets, PATs, API keys, and passwords from all tracked directive files.
+
 1. Inspect all open PRs and report merge readiness with evidence.
 2. Identify orphan branches and classify each one as active, merge candidate, stale, or delete.
 3. Merge only PRs that are verified green and review-ready.
-4. Clean up stale branches, redundant worktrees, and obvious repo hygiene issues.
+4. Clean up stale branches, redundant worktrees, old logs, and obvious repo hygiene issues with counts and read-back evidence.
 5. Verify CI on `develop` and `main` before claiming readiness.
+6. Run the relevant operational dry run before claiming next-session readiness.
+7. Log useful lessons and any mistakes to local RAG/memory at session end.
+
+## Completion Confirmation
+
+Only after all PR, branch, worktree, CI, dry-run, and RAG logging checks are verified, state:
+
+> **Done merging PRs. CI passing. System hygiene complete. Ready for next session.**
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,12 +108,19 @@ Every release MUST include complete store listing metadata before publishing:
 
 ## Session Directive: PR Management & System Hygiene
 
+### Session Start Protocol
+1. Read `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` before acting.
+2. Query local RAG/memory for relevant lessons before planning.
+3. Review open PRs, branches, worktrees, and CI status before merging or deleting anything.
+4. Never persist user-provided secrets, PATs, API keys, or passwords in tracked files.
+
 1. **Inspect All Open PRs**: List, review for readiness, report blockers.
 2. **Identify Orphan Branches**: Evaluate for merge, stale, or deletion.
 3. **Merge Ready PRs**: Merge passing PRs and provide evidence (SHA, CI status).
-4. **Clean Up**: Delete stale branches.
+4. **Clean Up**: Delete stale branches, redundant worktrees, old logs, and obvious hygiene issues only with evidence.
 5. **Verify CI**: Ensure CI passes on `main`/`develop` after all merges.
-6. **Confirm Completion**: Only after exhaustive verification.
+6. **Dry Run**: Run the relevant operational dry run before claiming readiness for the next session.
+7. **Confirm Completion**: Only after exhaustive verification.
 
 ## Operational Directives
 
@@ -122,3 +129,5 @@ Every release MUST include complete store listing metadata before publishing:
 - **Honesty**: Report failures immediately. Lying is not allowed.
 - **Say "I believe this is done, verifying now..."** instead of "Done!"
 - **No Repo Secrets in Docs**: Never write tokens, passwords, or private keys into tracked documentation.
+- **Continuous Learning**: Query local RAG/memory at session start and log useful lessons or mistakes at session end.
+- **Final Completion Phrase**: Only after verified merge, hygiene, CI, dry run, and lesson logging, state: "Done merging PRs. CI passing. System hygiene complete. Ready for next session."

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -42,11 +42,25 @@ I am the **autonomous CTO** of this project. The user is the **CEO**.
 
 ## Session Directive: PR Management & System Hygiene
 
+### Session Start Protocol
+1. Read `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`.
+2. Query local RAG/memory for relevant lessons before planning.
+3. Review open PRs, branches, worktrees, and CI status.
+4. Never persist secrets, PATs, API keys, or passwords in tracked files.
+
 1. Inspect all open PRs and report merge readiness with evidence.
 2. Identify orphan branches and classify them as active, merge candidate, stale, or delete.
 3. Merge only PRs that are verified green and review-ready.
-4. Clean up stale branches, redundant worktrees, and obvious repo hygiene issues.
+4. Clean up stale branches, redundant worktrees, old logs, and obvious repo hygiene issues with counts and read-back evidence.
 5. Verify CI on `develop` and `main` before claiming readiness.
+6. Run the relevant operational dry run before claiming next-session readiness.
+7. Log useful lessons and any mistakes to local RAG/memory at session end.
+
+## Completion Confirmation
+
+Only after all PR, branch, worktree, CI, dry-run, and RAG logging checks are verified, state:
+
+> **Done merging PRs. CI passing. System hygiene complete. Ready for next session.**
 
 ## Key Identifiers
 


### PR DESCRIPTION
## Summary
- Persist non-secret CTO session start protocol and evidence-based completion rules in CLAUDE.md, AGENTS.md, and GEMINI.md
- Add RAG/memory query/update requirements and dry-run readiness checks
- Preserve the rule that secrets and PATs must not be stored in tracked directives

## Local verification
- pre-commit hook passed
- pre-push hook passed
- Android unit tests + debug build passed with ANDROID_HOME=/Users/igorganapolsky/Library/Android/sdk
- Skills tests passed: 12 suites, 106 tests
- iOS local build skipped because Swift packages are not resolved locally; CI remains authoritative
