### PR TITLE
fix: wire gateway analytics to PostHog

### DIFF
--- a/docs/posthog-analytics.md
+++ b/docs/posthog-analytics.md
@@ -1,0 +1,54 @@
+# PostHog Analytics
+
+OpenClaw Console uses PostHog for server-side product analytics and North Star read-back.
+
+## Environment
+
+Use separate keys for capture and query:
+
+- `POSTHOG_PROJECT_API_KEY` or `POSTHOG_PROJECT_TOKEN`: project token used by the gateway to capture events.
+- `POSTHOG_API_KEY`: supported as the legacy project-token name for capture only.
+- `POSTHOG_PERSONAL_API_KEY`: personal API key used by `scripts/north_star_guardrail.py` to query HogQL.
+- `POSTHOG_PROJECT_ID`: numeric PostHog project ID used by HogQL queries.
+- `POSTHOG_HOST`: optional host override. Defaults to `https://us.i.posthog.com`.
+- `POSTHOG_SEND_RAW_EMAIL`: optional. Set to `true` only if raw email capture is explicitly allowed.
+
+Do not use `POSTHOG_PERSONAL_API_KEY` for event capture. Do not use the project token for HogQL queries. Prefer `POSTHOG_PROJECT_API_KEY` for new configuration so capture tokens are not confused with personal API keys.
+
+## Captured Events
+
+Gateway analytics captures conversion and lifecycle events from `openclaw-skills/src/analytics/events.ts`.
+
+Key events:
+
+- `app_install`
+- `account_created`
+- `first_approval`
+- `approval_completed`
+- `subscription_started`
+- `subscription_cancelled`
+- `feature_used`
+- `integration_connected`
+- `error_encountered`
+
+`first_approval` and `approval_completed` both count toward Daily Active Approvers.
+
+## Privacy
+
+PostHog person properties are sent through `$set`. Raw email is stripped by default, even if callers pass `email`. Set `POSTHOG_SEND_RAW_EMAIL=true` only when the privacy policy and product settings explicitly allow raw email analytics.
+
+## Read-Back
+
+The gateway exposes a secret-safe status endpoint:
+
+```bash
+GET /api/analytics/status
+```
+
+It reports whether local analytics, Firebase, and PostHog are configured without returning tokens.
+
+The North Star guardrail queries PostHog with HogQL:
+
+```bash
+python3 scripts/north_star_guardrail.py --require-posthog
+```

--- a/openclaw-skills/src/analytics/events.ts
+++ b/openclaw-skills/src/analytics/events.ts
@@ -252,7 +252,8 @@ async function bestEffortPostHogIdentify(
     await identifyUserInPostHog(userId, properties);
   } catch (error) {
     console.warn(
-      `[Analytics] PostHog identify skipped for user ${userId}:`,
+      '[Analytics] PostHog identify skipped for user:',
+      userId,
       error instanceof Error ? error.message : 'unknown error'
     );
   }

--- a/openclaw-skills/src/analytics/events.ts
+++ b/openclaw-skills/src/analytics/events.ts
@@ -7,6 +7,7 @@ export type ConversionEvent =
   | 'app_install'
   | 'account_created'
   | 'first_approval'
+  | 'approval_completed'
   | 'subscription_started'
   | 'subscription_cancelled'
   | 'feature_used'
@@ -65,6 +66,29 @@ const conversionFunnels = new Map<string, ConversionFunnel>();
 const FIREBASE_PROJECT_ID = process.env.FIREBASE_PROJECT_ID;
 // const FIREBASE_PRIVATE_KEY = process.env.FIREBASE_PRIVATE_KEY; // Reserved for future use
 // const FIREBASE_CLIENT_EMAIL = process.env.FIREBASE_CLIENT_EMAIL; // Reserved for future use
+
+const POSTHOG_DEFAULT_HOST = 'https://us.i.posthog.com';
+
+interface PostHogConfig {
+  enabled: boolean;
+  host: string;
+  captureUrl: string;
+  projectApiKey?: string;
+  rawEmailEnabled: boolean;
+}
+
+export interface AnalyticsProviderStatus {
+  local: { enabled: true; eventCount: number; revenueEventCount: number; userCount: number };
+  firebase: { enabled: boolean; projectConfigured: boolean };
+  posthog: {
+    enabled: boolean;
+    host: string;
+    projectApiKeyConfigured: boolean;
+    personalApiKeyConfigured: boolean;
+    projectIdConfigured: boolean;
+    rawEmailEnabled: boolean;
+  };
+}
 
 // A/B testing configuration
 interface ABTestConfig {
@@ -131,6 +155,151 @@ function initializeFirebaseAnalytics(): { success: boolean; error?: string } {
   }
 }
 
+function posthogConfig(): PostHogConfig {
+  const host = (process.env.POSTHOG_HOST || POSTHOG_DEFAULT_HOST).replace(/\/+$/, '');
+  const projectApiKey = (
+    process.env.POSTHOG_PROJECT_API_KEY?.trim()
+    || process.env.POSTHOG_PROJECT_TOKEN?.trim()
+    || process.env.POSTHOG_API_KEY?.trim()
+    || ''
+  );
+
+  return {
+    enabled: projectApiKey.length > 0,
+    host,
+    captureUrl: `${host}/capture/`,
+    projectApiKey: projectApiKey || undefined,
+    rawEmailEnabled: process.env.POSTHOG_SEND_RAW_EMAIL === 'true'
+  };
+}
+
+function cleanProperties(
+  properties: Record<string, unknown> | undefined,
+  options: { includeEmail?: boolean } = {}
+): Record<string, string | number | boolean> {
+  const cleaned: Record<string, string | number | boolean> = {};
+
+  for (const [key, value] of Object.entries(properties || {})) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (key === 'email' && !options.includeEmail) {
+      continue;
+    }
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      cleaned[key] = value;
+    }
+  }
+
+  return cleaned;
+}
+
+async function postToPostHog(body: Record<string, unknown>): Promise<void> {
+  const config = posthogConfig();
+  if (!config.enabled || !config.projectApiKey) {
+    return;
+  }
+
+  const response = await fetch(config.captureUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: config.projectApiKey,
+      ...body
+    })
+  });
+
+  if (!response.ok) {
+    const details = await response.text().catch(() => '');
+    throw new Error(`PostHog capture failed: HTTP ${response.status}${details ? ` ${details}` : ''}`);
+  }
+}
+
+async function sendToPostHog(event: AnalyticsEvent): Promise<void> {
+  const config = posthogConfig();
+  if (!config.enabled) {
+    return;
+  }
+
+  const userProperties = cleanProperties(event.userProperties, { includeEmail: config.rawEmailEnabled });
+  await postToPostHog({
+    event: event.event,
+    distinct_id: event.userId,
+    timestamp: event.timestamp,
+    properties: {
+      ...cleanProperties(event.properties),
+      ...(Object.keys(userProperties).length > 0 ? { $set: userProperties } : {})
+    }
+  });
+}
+
+async function bestEffortPostHogCapture(event: AnalyticsEvent): Promise<void> {
+  try {
+    await sendToPostHog(event);
+  } catch (error) {
+    console.warn(
+      '[Analytics] PostHog capture skipped:',
+      error instanceof Error ? error.message : 'unknown error'
+    );
+  }
+}
+
+async function bestEffortPostHogIdentify(
+  userId: string,
+  properties: Record<string, string | number | boolean | undefined>
+): Promise<void> {
+  try {
+    await identifyUserInPostHog(userId, properties);
+  } catch (error) {
+    console.warn(
+      `[Analytics] PostHog identify skipped for user ${userId}:`,
+      error instanceof Error ? error.message : 'unknown error'
+    );
+  }
+}
+
+async function identifyUserInPostHog(
+  userId: string,
+  properties: Record<string, string | number | boolean | undefined>
+): Promise<void> {
+  const config = posthogConfig();
+  if (!config.enabled) {
+    return;
+  }
+
+  await postToPostHog({
+    event: '$identify',
+    distinct_id: userId,
+    properties: {
+      $set: cleanProperties(properties, { includeEmail: config.rawEmailEnabled })
+    }
+  });
+}
+
+export function getAnalyticsProviderStatus(): AnalyticsProviderStatus {
+  const config = posthogConfig();
+  return {
+    local: {
+      enabled: true,
+      eventCount: analyticsEvents.length,
+      revenueEventCount: revenueEvents.length,
+      userCount: conversionFunnels.size
+    },
+    firebase: {
+      enabled: Boolean(FIREBASE_PROJECT_ID),
+      projectConfigured: Boolean(FIREBASE_PROJECT_ID)
+    },
+    posthog: {
+      enabled: config.enabled,
+      host: config.host,
+      projectApiKeyConfigured: Boolean(config.projectApiKey),
+      personalApiKeyConfigured: Boolean(process.env.POSTHOG_PERSONAL_API_KEY?.trim()),
+      projectIdConfigured: Boolean(process.env.POSTHOG_PROJECT_ID?.trim()),
+      rawEmailEnabled: config.rawEmailEnabled
+    }
+  };
+}
+
 /**
  * Track a conversion event
  */
@@ -163,6 +332,9 @@ export async function trackConversionEvent(
     if (FIREBASE_PROJECT_ID) {
       await sendToFirebaseAnalytics(analyticsEvent);
     }
+
+    // Send server-side product events to PostHog when a project API key is configured.
+    await bestEffortPostHogCapture(analyticsEvent);
 
     console.log(`[Analytics] Event tracked: ${event} for user ${userId}`);
     return { success: true };
@@ -259,6 +431,8 @@ export async function identifyUser(
       properties.cohort_week = cohortWeek;
     }
 
+    await bestEffortPostHogIdentify(userId, properties);
+
     // Track user identification as event
     await trackConversionEvent('account_created', userId, {
       source: properties.install_source || 'unknown'
@@ -301,6 +475,7 @@ function updateConversionFunnel(userId: string, event: ConversionEvent, timestam
       break;
 
     case 'first_approval':
+    case 'approval_completed':
       funnel.firstApprovalDate = timestamp;
       funnel.currentStage = 'activated';
       break;
@@ -584,6 +759,24 @@ export function createAnalyticsRouter(): Router {
 
     } catch (error) {
       console.error('[Analytics] Conversion endpoint error:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error'
+      });
+      return;
+    }
+  });
+
+  // Get analytics provider configuration status without exposing secrets
+  router.get('/status', (_req: Request, res: Response) => {
+    try {
+      res.json({
+        success: true,
+        providers: getAnalyticsProviderStatus()
+      });
+      return;
+    } catch (error) {
+      console.error('[Analytics] Status endpoint error:', error);
       res.status(500).json({
         success: false,
         error: error instanceof Error ? error.message : 'Internal server error'

--- a/openclaw-skills/tests/analytics/events.test.ts
+++ b/openclaw-skills/tests/analytics/events.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import {
   trackConversionEvent,
   trackRevenue,
   identifyUser,
   getConversionAnalytics,
-  getABTestAssignment
+  getABTestAssignment,
+  getAnalyticsProviderStatus
 } from '../../src/analytics/events.js';
 
 describe('Analytics Events', () => {
@@ -37,6 +38,16 @@ describe('Analytics Events', () => {
       const result = await trackConversionEvent('first_approval', 'test-user-3', {
         action_type: 'deployment',
         agent_id: 'deploy-bot'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should track approval completed as an activation event', async () => {
+      const result = await trackConversionEvent('approval_completed', 'test-user-approval-completed', {
+        action_type: 'shell_command',
+        agent_id: 'approval-gate'
       });
 
       expect(result.success).toBe(true);
@@ -172,6 +183,123 @@ describe('Analytics Events', () => {
       expect(['control', 'simplified', 'gamified']).toContain(assignment.variant);
       expect(assignment.properties).toHaveProperty('flow_type');
       expect(assignment.properties).toHaveProperty('steps');
+    });
+  });
+
+  describe('PostHog integration', () => {
+    const originalEnv = { ...process.env };
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+      global.fetch = originalFetch;
+    });
+
+    it('should report PostHog disabled when no project API key is configured', () => {
+      delete process.env.POSTHOG_PROJECT_API_KEY;
+      delete process.env.POSTHOG_PROJECT_TOKEN;
+      delete process.env.POSTHOG_API_KEY;
+
+      const status = getAnalyticsProviderStatus();
+
+      expect(status.posthog.enabled).toBe(false);
+      expect(status.posthog.host).toBe('https://us.i.posthog.com');
+      expect(status.posthog.projectApiKeyConfigured).toBe(false);
+    });
+
+    it('should treat legacy POSTHOG_API_KEY as a capture project key', () => {
+      delete process.env.POSTHOG_PROJECT_API_KEY;
+      delete process.env.POSTHOG_PROJECT_TOKEN;
+      process.env.POSTHOG_API_KEY = 'phc_legacy_project_key';
+
+      const status = getAnalyticsProviderStatus();
+
+      expect(status.posthog.enabled).toBe(true);
+      expect(status.posthog.projectApiKeyConfigured).toBe(true);
+    });
+
+    it('should send conversion events to PostHog capture API when configured', async () => {
+      process.env.POSTHOG_PROJECT_API_KEY = 'phc_test_project_key';
+      process.env.POSTHOG_HOST = 'https://eu.i.posthog.com';
+
+      const calls: Array<{ url: string; body: unknown }> = [];
+      global.fetch = jest.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        calls.push({
+          url: String(url),
+          body: init?.body ? JSON.parse(String(init.body)) : undefined
+        });
+        return new Response('{}', { status: 200 });
+      }) as typeof fetch;
+
+      const result = await trackConversionEvent('approval_completed', 'posthog-user-1', {
+        action_type: 'deployment'
+      }, {
+        user_tier: 'pro_monthly',
+        email: 'private@example.com'
+      });
+
+      expect(result.success).toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe('https://eu.i.posthog.com/capture/');
+      expect(calls[0]?.body).toMatchObject({
+        api_key: 'phc_test_project_key',
+        event: 'approval_completed',
+        distinct_id: 'posthog-user-1',
+        properties: {
+          action_type: 'deployment',
+          platform: 'openclaw_console',
+          version: '1.0.0',
+          $set: {
+            user_tier: 'pro_monthly'
+          }
+        }
+      });
+      expect(JSON.stringify(calls[0]?.body)).not.toContain('private@example.com');
+    });
+
+    it('should not fail product behavior when PostHog capture is unavailable', async () => {
+      process.env.POSTHOG_PROJECT_API_KEY = 'phc_test_project_key';
+      global.fetch = jest.fn(async () => new Response('unavailable', { status: 503 })) as typeof fetch;
+
+      const result = await trackConversionEvent('approval_completed', 'posthog-outage-user');
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should send identify events with sanitized person properties', async () => {
+      process.env.POSTHOG_PROJECT_TOKEN = 'phc_test_project_token';
+
+      const calls: Array<{ body: unknown }> = [];
+      global.fetch = jest.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        calls.push({
+          body: init?.body ? JSON.parse(String(init.body)) : undefined
+        });
+        return new Response('{}', { status: 200 });
+      }) as typeof fetch;
+
+      const result = await identifyUser('posthog-identify-user', {
+        user_tier: 'free',
+        install_source: 'app_store',
+        device_type: 'ios',
+        email: 'private@example.com',
+        signup_date: '2026-03-06T12:00:00Z'
+      });
+
+      expect(result.success).toBe(true);
+      expect(calls[0]?.body).toMatchObject({
+        event: '$identify',
+        distinct_id: 'posthog-identify-user',
+        properties: {
+          $set: {
+            user_tier: 'free',
+            install_source: 'app_store',
+            device_type: 'ios',
+            signup_date: '2026-03-06T12:00:00Z',
+            cohort_week: '2026-W10'
+          }
+        }
+      });
+      expect(JSON.stringify(calls[0]?.body)).not.toContain('private@example.com');
     });
   });
 });

--- a/scripts/north_star_guardrail.py
+++ b/scripts/north_star_guardrail.py
@@ -91,14 +91,22 @@ def _outside_grace(campaigns: List[Dict[str, Any]], grace_days: int, now: dt.dat
 
 
 def _query_posthog_daa_1d(api_key: str, project_id: str) -> int:
+    approval_events = (
+        "first_approval",
+        "approval_completed",
+        "approval_submitted",
+        "approval_approved",
+        "approval_action_taken",
+    )
+    quoted_events = ",".join(f"'{event}'" for event in approval_events)
     query = {
         "query": {
             "kind": "HogQLQuery",
             "query": (
-                "SELECT count(DISTINCT person_id) AS daa_1d "
+                "SELECT count(DISTINCT distinct_id) AS daa_1d "
                 "FROM events "
                 "WHERE timestamp > now() - interval 1 day "
-                "AND event IN ('approval_submitted','approval_approved','approval_action_taken')"
+                f"AND event IN ({quoted_events})"
             ),
         }
     }
@@ -139,7 +147,6 @@ def run(repo_root: Path, lookback_days: int, grace_days: int, active_statuses: L
 
     api_key = (
         os.getenv("POSTHOG_PERSONAL_API_KEY", "").strip()
-        or os.getenv("POSTHOG_API_KEY", "").strip()
         or os.getenv("posthog_api_key", "").strip()
     )
     project_id = os.getenv("POSTHOG_PROJECT_ID", "").strip()
@@ -161,7 +168,7 @@ def run(repo_root: Path, lookback_days: int, grace_days: int, active_statuses: L
             errors.append(status_reason)
     else:
         status = "skipped"
-        status_reason = "missing POSTHOG_PERSONAL_API_KEY/POSTHOG_API_KEY or POSTHOG_PROJECT_ID"
+        status_reason = "missing POSTHOG_PERSONAL_API_KEY or POSTHOG_PROJECT_ID"
 
     guardrail_violated = (
         len(active_campaigns) > 0 and daa_1d == 0 and active_outside_grace > 0

--- a/scripts/tests/test_north_star_guardrail.py
+++ b/scripts/tests/test_north_star_guardrail.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from scripts import north_star_guardrail
+
+
+class NorthStarPostHogQueryTests(unittest.TestCase):
+    def test_query_counts_distinct_ids_for_all_approval_event_names(self) -> None:
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"results": [[3]]}
+
+        with patch.object(north_star_guardrail.requests, "post", return_value=response) as post:
+            result = north_star_guardrail._query_posthog_daa_1d("phx_personal", "123")
+
+        self.assertEqual(result, 3)
+        payload = post.call_args.kwargs["json"]
+        query = payload["query"]["query"]
+        self.assertIn("count(DISTINCT distinct_id)", query)
+        self.assertIn("'first_approval'", query)
+        self.assertIn("'approval_completed'", query)
+        self.assertIn("'approval_submitted'", query)
+        self.assertIn("'approval_approved'", query)
+        self.assertIn("'approval_action_taken'", query)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- wire the OpenClaw gateway analytics sink to PostHog server-side capture
- separate capture project tokens from HogQL personal API keys
- include first approvals in the DAA North Star query
- add a sanitized analytics status endpoint and PostHog setup docs

## Why
The downloaded PostHog PDF is a marketing email export, not an implementation guide. The repo had PostHog readback for DAA, but gateway conversion events only stayed in memory and the DAA query missed the gateway `first_approval` activation event.

## Validation
- `npm test -- --runTestsByPath tests/analytics/events.test.ts` passed: 19 tests
- `npx tsc --noEmit` passed
- `npx eslint src/analytics/events.ts tests/analytics/events.test.ts --max-warnings 0` passed
- `python3 -m unittest scripts.tests.test_north_star_guardrail scripts.tests.test_ensure_testflight_visibility` passed: 7 tests
- `npm test` in `openclaw-skills` passed: 14 suites, 125 tests
- pre-push Android fallback checks passed: `testDebugUnitTest` and `assembleDebug`

## Notes
- Existing GitHub secrets include `POSTHOG_API_KEY`, `POSTHOG_PERSONAL_API_KEY`, and `POSTHOG_PROJECT_ID`; this PR keeps legacy `POSTHOG_API_KEY` compatibility for capture while documenting the cleaner `POSTHOG_PROJECT_API_KEY`/`POSTHOG_PROJECT_TOKEN` names.
- Real PostHog network capture is not verified locally because secret values are not readable from GitHub Actions secrets.