### PR TITLE
ci: use venv for self-hosted TestFlight Python

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -96,7 +96,10 @@ jobs:
         run: |
           set -euo pipefail
           python3 --version
-          python3 -m pip --version
+          python3 -m venv .venv-internal-distribution
+          echo "$PWD/.venv-internal-distribution/bin" >> "$GITHUB_PATH"
+          .venv-internal-distribution/bin/python -m pip install --upgrade pip
+          .venv-internal-distribution/bin/python -m pip --version
 
       - name: Install Pillow
         run: python3 -m pip install pillow


### PR DESCRIPTION
## Summary
- create a local Python virtualenv on self-hosted iOS distribution runners
- prepend that venv to PATH before installing Pillow and App Store Connect Python dependencies

## Root cause
Internal Distribution run `25339373944` failed before upload at iOS step `Install Pillow`. The Mac mini runner uses Homebrew Python 3.14, where global pip installs fail with PEP 668 `externally-managed-environment`.

## Validation
- workflow YAML parsed with Ruby YAML loader
- `git diff --check` passed
- local Python 3.14 venv creation and pip upgrade succeeded
- pre-commit passed
- pre-push passed: Android unit/debug build passed; skills tests passed 14 suites / 125 tests

## Impact
This should unblock the self-hosted TestFlight job so it can progress past Python dependency installation.