### PR TITLE
fix: support Kotlin 2.3 compiler options

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -63,10 +65,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
         buildConfig = true
@@ -87,6 +85,12 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
             excludes += "/META-INF/versions/9/OSGI-INF/MANIFEST.MF"
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 
@@ -122,7 +126,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:5.3.2")
     implementation("com.squareup.okhttp3:logging-interceptor:5.3.2")
 
-    // Kotlinx Serialization (1.8.1 is the latest version compatible with Kotlin 2.1.x)
+    // Kotlinx Serialization runtime.
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
 
     // Coroutines

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.android.application") version "8.9.2" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.21" apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.1.21" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.1.21" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.21" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.3.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.3.21" apply false
 }


### PR DESCRIPTION
## Summary
- bump Kotlin Android, serialization, and Compose Gradle plugins to 2.3.21 together
- migrate Android app JVM target configuration from deprecated `kotlinOptions.jvmTarget` to `compilerOptions`
- remove the stale Kotlin 2.1.x serialization-runtime comment

## Why
Dependabot PR #325 failed CI after bumping `org.jetbrains.kotlin.android` because Kotlin 2.3 rejects `jvmTarget: String` in `android/app/build.gradle.kts`. PR #291 separately bumps the Compose compiler plugin to the same Kotlin line. This combines the Kotlin plugin family and applies the required Gradle DSL migration in one branch.

Supersedes #325 and #291 once CI passes.

## Validation
- `python3 scripts/check_android_cli.py` -> passed with SDK fallback tools; Android CLI unavailable on PATH
- `python3 scripts/sync_app_icons.py --check` -> passed
- `./scripts/check-brand-parity.sh` -> passed
- `ANDROID_HOME=$HOME/Library/Android/sdk ANDROID_SDK_ROOT=$HOME/Library/Android/sdk ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:lintDebug --no-daemon` -> passed
- pre-commit hook -> passed Android compile
- pre-push hook -> passed release contract, Android guardrails, flaky quarantine, agent workflow settings, Android unit tests + debug build, skills tests (`14/14` suites, `125/125` tests)

## Notes
Release contract still reports the existing 3 warnings: dynamic Android versionCode, missing Android phone screenshots directory, and missing iOS fastlane screenshots directory.
