### PR TITLE
fix: repair TestFlight visibility verifier

### DIFF
--- a/scripts/ensure_testflight_visibility.py
+++ b/scripts/ensure_testflight_visibility.py
@@ -10,6 +10,7 @@ import sys
 import time
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
@@ -35,6 +36,32 @@ def csv(raw: str) -> list[str]:
 
 def is_internal_pseudo_group(name: str) -> bool:
     return " ".join(name.strip().lower().split()) in INTERNAL_PSEUDO_GROUPS
+
+
+def summarize_asc_error(body: str) -> str:
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return body.strip()[:1000] if body.strip() else "empty response body"
+
+    errors = payload.get("errors")
+    if not isinstance(errors, list):
+        return json.dumps(payload, sort_keys=True)[:1000]
+
+    summaries: list[str] = []
+    for error in errors:
+        if not isinstance(error, dict):
+            continue
+        parts = [
+            str(error.get("status") or "").strip(),
+            str(error.get("code") or "").strip(),
+            str(error.get("title") or "").strip(),
+            str(error.get("detail") or "").strip(),
+        ]
+        summary = " ".join(part for part in parts if part)
+        if summary:
+            summaries.append(summary)
+    return "; ".join(summaries)[:1000] if summaries else json.dumps(payload, sort_keys=True)[:1000]
 
 
 def private_key_from_env() -> str:
@@ -108,9 +135,16 @@ class ASCClient:
                 "Content-Type": "application/json",
             },
         )
-        with urlopen(req, timeout=30) as response:
-            body = response.read().decode("utf-8")
-            return json.loads(body) if body else {}
+        try:
+            with urlopen(req, timeout=30) as response:
+                body = response.read().decode("utf-8")
+                return json.loads(body) if body else {}
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"App Store Connect API {method} {path} failed: "
+                f"HTTP {exc.code} {exc.reason}: {summarize_asc_error(body)}"
+            ) from exc
 
     def get_all(self, path: str, *, params: dict[str, str] | None = None) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
@@ -118,8 +152,15 @@ class ASCClient:
         while True:
             if next_url:
                 req = Request(next_url, headers={"Authorization": f"Bearer {self.token}"})
-                with urlopen(req, timeout=30) as response:
-                    payload = json.loads(response.read().decode("utf-8"))
+                try:
+                    with urlopen(req, timeout=30) as response:
+                        payload = json.loads(response.read().decode("utf-8"))
+                except HTTPError as exc:
+                    body = exc.read().decode("utf-8", errors="replace")
+                    raise RuntimeError(
+                        f"App Store Connect API GET {path} page failed: "
+                        f"HTTP {exc.code} {exc.reason}: {summarize_asc_error(body)}"
+                    ) from exc
             else:
                 payload = self.request("GET", path, params=params)
             items.extend(payload.get("data", []))
@@ -194,13 +235,13 @@ class TestFlightVisibility:
         testers = payload.get("data", [])
         return testers[0] if testers else None
 
-    def app_store_user(self, email: str) -> dict[str, Any] | None:
+    def app_store_user(self, username: str) -> dict[str, Any] | None:
         payload = self.client.request(
             "GET",
             "/users",
             params={
-                "filter[email]": email,
-                "fields[users]": "email,roles,allAppsVisible",
+                "filter[username]": username,
+                "fields[users]": "username,roles,allAppsVisible",
                 "limit": "1",
             },
         )

--- a/scripts/tests/test_ensure_testflight_visibility.py
+++ b/scripts/tests/test_ensure_testflight_visibility.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import unittest
 
-from scripts.ensure_testflight_visibility import TestFlightVisibility, is_internal_pseudo_group
+from scripts.ensure_testflight_visibility import (
+    TestFlightVisibility,
+    is_internal_pseudo_group,
+    summarize_asc_error,
+)
 
 
 class FakeClient:
@@ -26,6 +30,7 @@ class FakeClient:
         self.visible_app_ids = visible_app_ids if visible_app_ids is not None else {"app-1"}
         self.group_requests = 0
         self.assigned_builds: list[tuple[str, str]] = []
+        self.user_query_params: dict[str, str] | None = None
 
     def request(self, method, path, *, params=None, payload=None):
         if path == "/apps":
@@ -49,12 +54,13 @@ class FakeClient:
                 self.tester_has_build = True
                 return {}
         if path == "/users":
+            self.user_query_params = params
             return {
                 "data": [
                     {
                         "id": "user-1",
                         "attributes": {
-                            "email": "iganapolsky@gmail.com",
+                            "username": "iganapolsky@gmail.com",
                             "roles": self.user_roles,
                             "allAppsVisible": self.all_apps_visible,
                         },
@@ -95,6 +101,8 @@ class TestInternalPseudoGroups(unittest.TestCase):
         self.assertEqual(result["required_testers_checked"], 1)
         self.assertEqual(result["required_testers_assigned"], 0)
         self.assertEqual(client.group_requests, 0)
+        self.assertEqual(client.user_query_params["filter[username]"], "iganapolsky@gmail.com")
+        self.assertEqual(client.user_query_params["fields[users]"], "username,roles,allAppsVisible")
 
     def test_pseudo_group_fails_when_required_tester_is_missing(self) -> None:
         client = FakeClient(user_exists=False)
@@ -134,6 +142,24 @@ class TestInternalPseudoGroups(unittest.TestCase):
         self.assertEqual(result["status"], "VISIBLE")
         self.assertEqual(result["required_testers_assigned"], 0)
         self.assertEqual(client.assigned_builds, [])
+
+    def test_summarizes_app_store_connect_error_body(self) -> None:
+        body = """
+        {
+          "errors": [
+            {
+              "status": "400",
+              "code": "PARAMETER_ERROR.INVALID",
+              "title": "A parameter has an invalid value",
+              "detail": "filter[email] is not a valid filter"
+            }
+          ]
+        }
+        """
+        summary = summarize_asc_error(body)
+        self.assertIn("400", summary)
+        self.assertIn("PARAMETER_ERROR.INVALID", summary)
+        self.assertIn("filter[email] is not a valid filter", summary)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use App Store Connect username filtering for internal user visibility checks
- include sanitized App Store Connect error bodies in verifier failures
- add unit coverage for the internal TestFlight pseudo-group lookup and error summarization

## Verification
- python3 -m unittest scripts.tests.test_ensure_testflight_visibility
- python3 -m unittest discover -s scripts/tests -p 'test_*.py'
- python3 -m py_compile scripts/ensure_testflight_visibility.py scripts/tests/test_ensure_testflight_visibility.py
- scripts/pre-commit
- scripts/pre-push

Context: Internal Distribution run 25341610603 uploaded and distributed build 1.0.0 (260504202504), then failed only in the post-upload visibility verifier because Apple returned HTTP 400 for the old /users query.