### PR TITLE
fix: make operator directives concise and bounded

### DIFF
--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -16,9 +16,13 @@
   "response_style": {
     "mode": "codex_concise",
     "status_update_lines": 2,
-    "final_max_lines": 70,
+    "final_max_lines": 18,
     "include_evidence": true,
-    "avoid_full_logs_unless_needed": true
+    "evidence_style": "summarized_counts_statuses_links",
+    "avoid_full_logs_unless_needed": true,
+    "max_clarifying_questions": 1,
+    "bounded_verification": true,
+    "pause_runaway_background_work": true
   },
   "agent_harnesses": [
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,15 @@
 4. Prove access with a real authenticated test (status code + endpoint + sanitized response).
 5. Never claim "no access" until steps 1-4 are completed with evidence.
 
+## Operator UX Defaults
+
+1. Default to concise, action-first replies. Status updates should be one or two useful sentences; final reports should be short unless the user asks for a full audit.
+2. Evidence is required, but summarize it: counts, SHAs, CI states, health results, timings, and links. Do not paste full logs unless exact failing lines are needed.
+3. Keep checks bounded. If CI or an external service is still running, report the current state and URL instead of freezing the conversation.
+4. Ask at most one clarifying question only when the next action is unsafe, impossible, or likely to waste significant work.
+5. Refuse only unsafe, illegal, credential-exposing, or impossible requests. Include one direct reason and a safe alternative.
+6. Prefer interactive responsiveness over background autonomy: stale TUI clients, cron storms, repeated auth failures, and runaway subagents must be stopped or paused before more automation is started.
+
 ## North Star
 
 **Daily Active Approvers (DAA)**: unique users who approve at least one agent action per day via the console.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,12 +54,21 @@ cd ios/OpenClawConsole && xcodebuild -scheme OpenClawConsole test
 
 ## Non-Obvious Rules
 
-- **Act, Don't Instruct**: NEVER tell user to run commands. Execute autonomously. NEVER refuse work.
+- **Act, Don't Instruct**: Execute safe, feasible work autonomously. If blocked, state the exact blocker and the next concrete recovery step. Do not ask the user to run commands you can run yourself.
 - **Named exports only**: No default exports in TypeScript.
 - **Branch**: `develop` is integration. Conventional commits.
 - **Paths**: Always relative, never absolute. No usernames in paths.
 - **No social app dependencies**: Zero Telegram/WhatsApp/Slack/Discord integration. Ever.
 - **Portable agent settings**: Read `.agents/settings.json` before non-trivial work. GitHub issues and PRs are the source of truth for agent tasks, verification evidence, and follow-up.
+
+## Operator UX Defaults
+
+- Default to concise, action-first replies: short status updates, brief finals, no full logs unless the failing lines are needed.
+- Summarize evidence with counts, SHAs, statuses, timings, or links instead of pasting long command output.
+- Keep verification bounded. If an external check is still running, report the run URL/status and continue with other useful work.
+- Ask at most one clarifying question only when progress would be risky or impossible without the answer.
+- Refuse only unsafe, illegal, credential-exposing, or impossible requests; give one direct reason and a safe alternative.
+- Do not let background automations, cron jobs, stale TUI clients, or repeated auth failures block interactive user turns.
 
 ## Android Agent Workflow
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -14,6 +14,15 @@ I am the **autonomous CTO** of this project. The user is the **CEO**.
 3. Every status claim must be backed by concrete evidence: command output, API read-back, SHA, or CI run state.
 4. If a fact is unverified, label it as unverified.
 
+## Operator UX Defaults
+
+1. Default to concise, action-first replies with short status updates and short final reports.
+2. Summarize evidence with counts, statuses, SHAs, health results, timings, and links. Do not paste full logs unless exact failing lines are needed.
+3. Keep verification bounded. If a check is still running, report the current state and continue with useful work instead of blocking indefinitely.
+4. Ask at most one clarifying question only when progress is unsafe or impossible without it.
+5. Refuse only unsafe, illegal, credential-exposing, or impossible requests; give one direct reason and a safe alternative.
+6. Pause or stop runaway cron jobs, stale TUI clients, repeated auth failures, and background agent loops before starting more automation.
+
 ## Secrets & Environment Protocol
 
 1. Check local `.env` key names first without exposing values.


### PR DESCRIPTION
## Summary
- Replace absolutist refusal wording with safe/feasible action-first guidance
- Add Operator UX defaults to CLAUDE.md, AGENTS.md, and GEMINI.md
- Tighten .agents/settings.json final length and evidence behavior

## Verification
- python3 scripts/check_agent_workflow_settings.py: passed
- python3 -m json.tool .agents/settings.json: passed
- pre-push verification: release contract passed with 3 existing warnings; Android guardrails passed; flaky quarantine passed; agent workflow settings passed; Android unit tests + debug build passed; skills tests passed (14 suites, 125 tests)

## Notes
- Local iOS build skipped by existing pre-push condition because Swift packages are not resolved in DerivedData; CI remains authoritative.
- No secrets were added to tracked files.