### PR TITLE
fix: route iOS CI to Mac mini runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
   ios-build:
     name: iOS Build Check
     needs: [ios-changes]
-    runs-on: ${{ needs.ios-changes.outputs.ios_changed == 'true' && 'macos-14' || 'ubuntu-latest' }}
+    runs-on: ${{ needs.ios-changes.outputs.ios_changed == 'true' && (vars.IOS_CI_RUNS_ON || 'macos-26') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -252,8 +252,21 @@ jobs:
         run: echo "No iOS files changed; skipping macOS simulator build."
 
       - name: Select Xcode
-        if: needs.ios-changes.outputs.ios_changed == 'true'
+        if: needs.ios-changes.outputs.ios_changed == 'true' && runner.environment != 'self-hosted'
         run: sudo xcode-select -s /Applications/Xcode_15.2.app
+
+      - name: Resolve simulator destination
+        if: needs.ios-changes.outputs.ios_changed == 'true'
+        id: simulator
+        run: |
+          SIMULATOR_NAME=$(xcrun simctl list devices available | sed -n 's/^[[:space:]]*\(iPhone[^()]*\) (.*/\1/p' | head -n 1)
+          if [ -n "$SIMULATOR_NAME" ]; then
+            DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME"
+          else
+            DESTINATION="generic/platform=iOS Simulator"
+          fi
+          echo "destination=$DESTINATION" >> "$GITHUB_OUTPUT"
+          echo "Using destination: $DESTINATION"
 
       - name: Resolve and build for simulator
         if: needs.ios-changes.outputs.ios_changed == 'true'
@@ -267,7 +280,7 @@ jobs:
           # Build with the same derivedDataPath and disable auto-resolution
           xcodebuild build \
             -scheme OpenClawConsole \
-            -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' \
+            -destination '${{ steps.simulator.outputs.destination }}' \
             -configuration Debug \
             -derivedDataPath .build/DerivedData \
             -disableAutomaticPackageResolution \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: macos-14
+    runs-on: ${{ vars.IOS_CI_RUNS_ON || 'macos-26' }}
     defaults:
       run:
         working-directory: ios/OpenClawConsole
@@ -20,16 +20,29 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Select Xcode 15.2
+        if: runner.environment != 'self-hosted'
         run: sudo xcode-select -s /Applications/Xcode_15.2.app
 
+      - name: Resolve simulator destination
+        id: simulator
+        run: |
+          SIMULATOR_NAME=$(xcrun simctl list devices available | sed -n 's/^[[:space:]]*\(iPhone[^()]*\) (.*/\1/p' | head -n 1)
+          if [ -n "$SIMULATOR_NAME" ]; then
+            DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME"
+          else
+            DESTINATION="generic/platform=iOS Simulator"
+          fi
+          echo "destination=$DESTINATION" >> "$GITHUB_OUTPUT"
+          echo "Using destination: $DESTINATION"
+
       - name: Resolve Swift packages
-        run: xcodebuild -resolvePackageDependencies -scheme OpenClawConsole -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2'
+        run: xcodebuild -resolvePackageDependencies -scheme OpenClawConsole -destination '${{ steps.simulator.outputs.destination }}'
 
       - name: Build
         run: |
           xcodebuild build \
             -scheme OpenClawConsole \
-            -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' \
+            -destination '${{ steps.simulator.outputs.destination }}' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             | xcpretty
@@ -38,13 +51,13 @@ jobs:
         run: |
           xcodebuild test \
             -scheme OpenClawConsole \
-            -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' \
+            -destination '${{ steps.simulator.outputs.destination }}' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             | xcpretty
 
   lint:
-    runs-on: macos-14
+    runs-on: ${{ vars.IOS_CI_RUNS_ON || 'macos-26' }}
     defaults:
       run:
         working-directory: ios/OpenClawConsole
@@ -53,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install SwiftLint
-        run: brew install swiftlint
+        run: brew list swiftlint >/dev/null 2>&1 || brew install swiftlint
 
       - name: Lint
         run: swiftlint lint --strict --reporter github-actions-logging

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"language":"javascript-typescript","os":"ubuntu-latest"}]' || '[{"language":"javascript-typescript","os":"ubuntu-latest"},{"language":"java-kotlin","os":"ubuntu-latest"},{"language":"swift","os":"macos-latest"}]') }}
+        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"language":"javascript-typescript","os":"ubuntu-latest"}]' || '[{"language":"javascript-typescript","os":"ubuntu-latest"},{"language":"java-kotlin","os":"ubuntu-latest"},{"language":"swift","os":"macos-26"}]') }}
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
## Summary
- route iOS CI and CI iOS Build Check to the Mac mini runner label by default
- skip GitHub-hosted Xcode 15.2 selection on self-hosted runners
- resolve simulator destinations dynamically instead of hard-coding iPhone 15 / iOS 17.2
- run Swift CodeQL on the macos-26 self-hosted label

## Verification
- actionlint .github/workflows/ci.yml .github/workflows/ios.yml .github/workflows/security.yml
- scripts/pre-commit
- scripts/pre-push (Android debug/unit gate passed; skills tests 15 suites / 131 tests passed; local iOS build intentionally skipped per hook because Swift packages are not resolved locally)