### PR TITLE
fix: skip internal distribution for docs-only merges

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -25,6 +25,12 @@ jobs:
       sha: ${{ steps.decide.outputs.sha }}
       reason: ${{ steps.decide.outputs.reason }}
     steps:
+      - uses: actions/checkout@v5
+        if: github.event_name == 'workflow_run'
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+
       - name: Decide whether to run
         id: decide
         env:
@@ -34,6 +40,7 @@ jobs:
           WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
           ALLOWED_BRANCHES: "develop main"
           INPUT_REF: ${{ inputs.ref }}
+          DISTRIBUTION_PATH_REGEX: '^(android/|ios/|scripts/(preflight-release\.sh|sync_app_icons\.py|sync-android-launcher-icon\.sh|validate_release_contract\.py)|\.github/workflows/(internal-distribution|native-release|android|ios)\.yml$)'
         run: |
           set -euo pipefail
 
@@ -61,6 +68,26 @@ jobs:
 
             REF="$WORKFLOW_SHA"
             SHA="$WORKFLOW_SHA"
+
+            if git rev-parse "${WORKFLOW_SHA}^" >/dev/null 2>&1; then
+              CHANGED_FILES="$(git diff --name-only "${WORKFLOW_SHA}^" "$WORKFLOW_SHA")"
+            else
+              CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r "$WORKFLOW_SHA" || true)"
+            fi
+
+            if ! grep -Eq "$DISTRIBUTION_PATH_REGEX" <<< "$CHANGED_FILES"; then
+              REASON="no_distribution_paths_changed"
+              echo "gate: skipping internal distribution; changed files do not affect mobile release artifacts"
+              printf '%s\n' "$CHANGED_FILES" | sed 's/^/gate: changed: /'
+              {
+                echo "should_run=$SHOULD_RUN"
+                echo "ref=$REF"
+                echo "sha=$SHA"
+                echo "reason=$REASON"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             SHOULD_RUN="true"
             REASON="ci_green_on_${WORKFLOW_BRANCH}"
           fi


### PR DESCRIPTION
## Summary
- add changed-file gating to Internal Distribution workflow_run events
- keep manual dispatch behavior unchanged
- skip Firebase/TestFlight when only directives/docs/settings changed

## Verification
- actionlint .github/workflows/internal-distribution.yml
- python3 scripts/check_android_cli.py
- python3 scripts/validate_release_contract.py --platform android
- simulated gate: a29669e => skip, 09f988b => run
- scripts/pre-commit
- scripts/pre-push (Android debug/unit build, skills tests 15 suites / 131 tests)

## Evidence
- Prevents repeat of cancelled Internal Distribution run 25379404016, which started after directive-only merge a29669e.