### PR TITLE
fix: restrict internal distribution to app artifact changes

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -40,7 +40,7 @@ jobs:
           WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
           ALLOWED_BRANCHES: "develop main"
           INPUT_REF: ${{ inputs.ref }}
-          DISTRIBUTION_PATH_REGEX: '^(android/|ios/|scripts/(preflight-release\.sh|sync_app_icons\.py|sync-android-launcher-icon\.sh|validate_release_contract\.py)|\.github/workflows/(internal-distribution|native-release|android|ios)\.yml$)'
+          DISTRIBUTION_PATH_REGEX: '^(android/|ios/)'
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- restrict automatic Internal Distribution to commits that change android/ or ios/ paths
- keep manual workflow_dispatch distribution unchanged
- prevents workflow/directive-only merges from uploading duplicate TestFlight/Firebase builds

## Verification
- actionlint .github/workflows/internal-distribution.yml
- simulated gate: 286dbc5 => skip, a29669e => skip, 09f988b => run
- python3 scripts/check_android_cli.py
- scripts/pre-commit
- scripts/pre-push (Android debug/unit build, skills tests 15 suites / 131 tests)