### PR TITLE
fix: use Xcode 26 for TestFlight uploads

### DIFF
--- a/.github/workflows/internal-distribution.yml
+++ b/.github/workflows/internal-distribution.yml
@@ -104,7 +104,7 @@ jobs:
     name: iOS TestFlight (Internal)
     needs: [gate]
     if: needs.gate.outputs.should_run == 'true'
-    runs-on: ${{ fromJSON(vars.IOS_TESTFLIGHT_RUNS_ON || '"macos-26"') }}
+    runs-on: macos-26
     timeout-minutes: 45
     environment: production
     steps:
@@ -143,9 +143,10 @@ jobs:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          REVENUECAT_PUBLIC_KEY: ${{ secrets.REVENUECAT_PUBLIC_KEY }}
         run: |
           set -euo pipefail
-          for name in MATCH_GIT_URL MATCH_PASSWORD MATCH_GIT_BASIC_AUTHORIZATION APPSTORE_PRIVATE_KEY APPSTORE_KEY_ID APPSTORE_ISSUER_ID ADMIN_TOKEN; do
+          for name in MATCH_GIT_URL MATCH_PASSWORD MATCH_GIT_BASIC_AUTHORIZATION APPSTORE_PRIVATE_KEY APPSTORE_KEY_ID APPSTORE_ISSUER_ID ADMIN_TOKEN REVENUECAT_PUBLIC_KEY; do
             if [ -z "${!name:-}" ]; then
               echo "❌ Missing required secret: $name"
               exit 1
@@ -244,6 +245,7 @@ jobs:
           TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: ${{ vars.TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS || 'false' }}
           TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING: "true"
           TESTFLIGHT_ARCHIVE_ONLY: "true"
+          REVENUECAT_PUBLIC_KEY: ${{ secrets.REVENUECAT_PUBLIC_KEY }}
         run: |
           set -Eeuo pipefail
           bundle exec fastlane beta --verbose 2>&1 | tee fastlane-archive.log
@@ -268,6 +270,7 @@ jobs:
           TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: ${{ vars.TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS || 'false' }}
           TESTFLIGHT_SKIP_WAITING_FOR_BUILD_PROCESSING: "false"
           TESTFLIGHT_UPLOAD_ONLY: "true"
+          REVENUECAT_PUBLIC_KEY: ${{ secrets.REVENUECAT_PUBLIC_KEY }}
         run: |
           set -Eeuo pipefail
           bundle exec fastlane beta --verbose 2>&1 | tee fastlane-upload.log
@@ -354,6 +357,7 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
           GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          REVENUECAT_PUBLIC_KEY: ${{ secrets.REVENUECAT_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           if [ -z "${GOOGLE_SERVICES_JSON:-}" ]; then
@@ -362,6 +366,10 @@ jobs:
           fi
           if [ -z "${ANDROID_KEYSTORE_BASE64:-}" ]; then
             echo "❌ Missing required secret: ANDROID_KEYSTORE_BASE64"
+            exit 1
+          fi
+          if [ -z "${REVENUECAT_PUBLIC_KEY:-}" ]; then
+            echo "❌ Missing required secret: REVENUECAT_PUBLIC_KEY"
             exit 1
           fi
 
@@ -438,6 +446,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          REVENUECAT_PUBLIC_KEY: ${{ secrets.REVENUECAT_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           ./gradlew assembleRelease --no-daemon

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -38,18 +38,44 @@ concurrency:
 jobs:
   ios-testflight:
     if: ${{ inputs.platform == 'ios' || inputs.platform == 'both' }}
-    runs-on: macos-15
+    runs-on: macos-26
     environment: production
     steps:
       - uses: actions/checkout@v5
 
+      - name: Verify Xcode 26 upload SDK
+        run: |
+          set -euo pipefail
+          xcodebuild -version
+          sdk_version="$(xcrun --sdk iphoneos --show-sdk-version)"
+          echo "iphoneos SDK: ${sdk_version}"
+          sdk_major="${sdk_version%%.*}"
+          if [ "${sdk_major}" -lt 26 ]; then
+            echo "❌ App Store Connect requires iOS SDK 26 or later for uploads."
+            exit 1
+          fi
+
       - name: Setup Python
+        if: ${{ runner.environment == 'github-hosted' }}
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
+      - name: Verify self-hosted Python
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: |
+          set -euo pipefail
+          python3 --version
+          python3 -m pip --version
+
       - name: Install Pillow
-        run: python3 -m pip install pillow
+        run: |
+          set -euo pipefail
+          if python3 -c "import PIL" >/dev/null 2>&1; then
+            echo "Pillow already available"
+            exit 0
+          fi
+          python3 -m pip install pillow
 
       - name: Fail fast on required iOS release secrets
         env:

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -12,7 +12,8 @@ platform :android do
 
     gradle(task: "bundleRelease")
 
-    aab_path = "app/build/outputs/bundle/release/app-release.aab"
+    aab_path = lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH] ||
+      File.expand_path("../app/build/outputs/bundle/release/app-release.aab", __dir__)
     UI.user_error!("Release bundle not found at #{aab_path}") unless File.exist?(aab_path)
 
     upload_to_play_store(


### PR DESCRIPTION
## Summary
- move the TestFlight release job to the GA macOS 26 runner so uploads build with iOS SDK 26+
- add an explicit iphoneos SDK major-version gate before spending time on signing/building

## Evidence
- actionlint .github/workflows/native-release.yml
- bash scripts/preflight-release.sh --platform ios --layer 1
- pre-push hook: release contract, Android guardrails, Android debug build + unit tests, skills tests (15 suites / 131 tests)

## Failure fixed
Native App Release run 25387511435 failed iOS upload because App Store Connect rejected the IPA built with iOS 18.5 SDK and required iOS SDK 26 or later.