### PR TITLE
fix: add quiet gateway pairing mode

### DIFF
--- a/openclaw-skills/package.json
+++ b/openclaw-skills/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/index.ts",
+    "pair": "node scripts/pair.mjs",
+    "pair:server": "tsx src/index.ts",
     "start": "node dist/index.js",
     "test": "node --experimental-vm-modules node_modules/.bin/jest --passWithNoTests",
     "lint": "eslint src tests --ext .ts"

--- a/openclaw-skills/scripts/pair.mjs
+++ b/openclaw-skills/scripts/pair.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import os from 'node:os';
+import { spawn } from 'node:child_process';
+
+const port = process.env.PORT || '18789';
+const publicUrl = process.env.OPENCLAW_PUBLIC_URL || inferPublicUrl(port);
+const pairPageUrl = `http://127.0.0.1:${port}/pair`;
+
+if (!publicUrl) {
+  console.error('Could not find a LAN IP address for this Mac.');
+  console.error('Set OPENCLAW_PUBLIC_URL manually, for example: OPENCLAW_PUBLIC_URL=http://192.168.1.20:18789 npm run pair');
+  process.exit(1);
+}
+
+const env = {
+  ...process.env,
+  PORT: port,
+  HOST: process.env.HOST || '0.0.0.0',
+  OPENCLAW_PUBLIC_URL: publicUrl,
+  OPENCLAW_PAIRING_MODE: 'true',
+  LOAD_SEED_DATA: 'false',
+  SIMULATE_BRIDGES: 'false',
+  ENABLED_SKILLS: '',
+};
+
+console.log('');
+console.log('OpenClaw pairing mode');
+console.log(`Gateway URL for phone: ${publicUrl}`);
+console.log(`QR page on this Mac: ${pairPageUrl}`);
+console.log('');
+
+const child = spawn('npm', ['run', 'pair:server', '--silent'], {
+  env,
+  stdio: ['inherit', 'pipe', 'pipe'],
+});
+
+let opened = false;
+
+child.stdout.on('data', (chunk) => {
+  const text = chunk.toString();
+  process.stdout.write(text);
+  if (!opened && text.includes('OpenClaw gateway listening')) {
+    opened = true;
+    openBrowser(pairPageUrl);
+  }
+});
+
+child.stderr.on('data', (chunk) => {
+  process.stderr.write(chunk);
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});
+
+process.on('SIGINT', () => child.kill('SIGINT'));
+process.on('SIGTERM', () => child.kill('SIGTERM'));
+
+function inferPublicUrl(listenPort) {
+  const interfaces = os.networkInterfaces();
+  const preferred = ['en0', 'en1', 'eth0', 'wlan0'];
+
+  for (const name of preferred) {
+    const address = firstUsableAddress(interfaces[name]);
+    if (address) {
+      return `http://${address}:${listenPort}`;
+    }
+  }
+
+  for (const [name, addresses] of Object.entries(interfaces)) {
+    if (/^(lo|utun|awdl|llw|docker|bridge|vbox|vmnet)/.test(name)) {
+      continue;
+    }
+    const address = firstUsableAddress(addresses);
+    if (address) {
+      return `http://${address}:${listenPort}`;
+    }
+  }
+
+  return null;
+}
+
+function firstUsableAddress(addresses = []) {
+  return addresses.find((entry) => {
+    return entry.family === 'IPv4' && !entry.internal && isPrivateLanAddress(entry.address);
+  })?.address;
+}
+
+function isPrivateLanAddress(address) {
+  return /^10\./.test(address)
+    || /^192\.168\./.test(address)
+    || /^172\.(1[6-9]|2\d|3[0-1])\./.test(address);
+}
+
+function openBrowser(url) {
+  if (process.env.OPENCLAW_PAIRING_OPEN_BROWSER === 'false') {
+    return;
+  }
+
+  const command = process.platform === 'darwin'
+    ? 'open'
+    : process.platform === 'win32'
+      ? 'cmd'
+      : 'xdg-open';
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  const opener = spawn(command, args, { stdio: 'ignore', detached: true });
+  opener.unref();
+}

--- a/openclaw-skills/src/analytics/events.ts
+++ b/openclaw-skills/src/analytics/events.ts
@@ -139,7 +139,9 @@ const AB_TESTS: { [testName: string]: ABTestConfig } = {
  */
 function initializeFirebaseAnalytics(): { success: boolean; error?: string } {
   if (!FIREBASE_PROJECT_ID) {
-    console.warn('[Analytics] Firebase not configured - using in-memory storage only');
+    if (process.env['OPENCLAW_PAIRING_MODE'] !== 'true') {
+      console.warn('[Analytics] Firebase not configured - using in-memory storage only');
+    }
     return { success: true }; // Not an error, just local mode
   }
 

--- a/openclaw-skills/src/billing/revenuecat.ts
+++ b/openclaw-skills/src/billing/revenuecat.ts
@@ -525,6 +525,6 @@ export function createBillingRouter(): Router {
 
 // Initialize on module load
 const initResult = initializeRevenueCat();
-if (!initResult.success) {
+if (!initResult.success && process.env['OPENCLAW_PAIRING_MODE'] !== 'true') {
   console.warn('[RevenueCat] Initialization failed:', initResult.error);
 }

--- a/openclaw-skills/src/config/default.ts
+++ b/openclaw-skills/src/config/default.ts
@@ -62,8 +62,8 @@ const DEFAULT_CONFIG: GatewayConfig = {
   wsPongTimeout: 10_000,
   approvalTimeoutMs: 5 * 60 * 1000, // 5 minutes
   requireBiometric: process.env['REQUIRE_BIOMETRIC'] !== 'false',
-  enabledSkills: ['ci-monitor', 'incident-manager', 'approval-gate', 'task-manager', 'trading-monitor', 'gitclaw-agent'],
-  isolatedSkills: process.env['ISOLATED_SKILLS']?.split(',') ?? [],
+  enabledSkills: parseList(process.env['ENABLED_SKILLS'], ['ci-monitor', 'incident-manager', 'approval-gate', 'task-manager', 'trading-monitor', 'gitclaw-agent', 'daily-brief']),
+  isolatedSkills: parseList(process.env['ISOLATED_SKILLS'], []),
   loadSeedData: process.env['LOAD_SEED_DATA'] !== 'false',
   simulateBridges: process.env['SIMULATE_BRIDGES'] !== 'false',
   mcpServers: process.env['MCP_SERVERS']?.split(';') ?? [],
@@ -77,6 +77,16 @@ const DEFAULT_CONFIG: GatewayConfig = {
   localModelTimeoutMs: parseInt(process.env['OPENCLAW_LOCAL_MODEL_TIMEOUT_MS'] ?? '2500', 10),
   governanceEventLogPath: process.env['OPENCLAW_GOVERNANCE_EVENT_LOG'] ?? './data/governance-events.jsonl',
 };
+
+function parseList(raw: string | undefined, fallback: string[]): string[] {
+  if (raw === undefined) {
+    return fallback;
+  }
+  return raw
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
 
 export function isApprovalPolicyPreset(raw: string): raw is ApprovalPolicyPreset {
   return raw === 'manual' || raw === 'safe-yolo' || raw === 'repo-yolo' || raw === 'ci-yolo' || raw === 'danger-yolo';

--- a/openclaw-skills/src/gateway/pairing.ts
+++ b/openclaw-skills/src/gateway/pairing.ts
@@ -34,13 +34,22 @@ export function isLocalPairingRequest(req: Request): boolean {
 
 export function inferGatewayBaseUrl(req: Request, config: GatewayConfig): string {
   const explicit = process.env['OPENCLAW_PUBLIC_URL']?.trim();
-  if (explicit) {
+  if (explicit && isUsableBaseUrl(explicit)) {
     return trimTrailingSlashes(explicit);
   }
 
   const host = String(req.headers['x-forwarded-host'] ?? req.headers.host ?? `${config.host}:${config.port}`);
   const proto = String(req.headers['x-forwarded-proto'] ?? req.protocol ?? 'http').split(',')[0]?.trim() || 'http';
   return trimTrailingSlashes(`${proto}://${host}`);
+}
+
+function isUsableBaseUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && parsed.hostname.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 export function buildGatewayPairingPayload(

--- a/openclaw-skills/src/gateway/remote-api.ts
+++ b/openclaw-skills/src/gateway/remote-api.ts
@@ -62,5 +62,7 @@ export function registerRemoteApi(app: Express, state: StateManager): void {
     }
   });
 
-  console.info('[remote-api] Registered routes for isolated skills');
+  if (process.env['OPENCLAW_PAIRING_MODE'] !== 'true') {
+    console.info('[remote-api] Registered routes for isolated skills');
+  }
 }

--- a/openclaw-skills/src/gateway/server.ts
+++ b/openclaw-skills/src/gateway/server.ts
@@ -693,9 +693,11 @@ export function createGatewayServer(
           console.info(`[gateway] OpenClaw gateway listening on http://${config.host}:${config.port}`); // local-dev-only
           // Dev hint: connect via WebSocket using your dev auth bearer credential
           const wsEndpoint = `ws://${config.host}:${config.port}/ws`; // local-dev-only
-          console.info(`[gateway] WebSocket endpoint: ${wsEndpoint} (add bearer auth header)`); // local-dev-only
+          if (process.env['OPENCLAW_PAIRING_MODE'] !== 'true') {
+            console.info(`[gateway] WebSocket endpoint: ${wsEndpoint} (add bearer auth header)`); // local-dev-only
+          }
           const devToken = tokenManager.getDefaultDevToken();
-          if (devToken) {
+          if (devToken && process.env['OPENCLAW_PAIRING_MODE'] !== 'true') {
             console.info(`[gateway] Dev credential prefix: ${devToken.slice(0, 8)}…`);
           }
           resolve();

--- a/openclaw-skills/src/index.ts
+++ b/openclaw-skills/src/index.ts
@@ -18,8 +18,10 @@ import { GitClawAgentSkill } from './skills/gitclaw-agent.js';
 import { AGENT_IDS } from './config/agents.js';
 
 async function main(): Promise<void> {
+  const pairingMode = process.env['OPENCLAW_PAIRING_MODE'] === 'true';
+
   console.info('='.repeat(60));
-  console.info('  OpenClaw Work Console Gateway');
+  console.info(pairingMode ? '  OpenClaw Gateway Pairing' : '  OpenClaw Work Console Gateway');
   console.info(`  Version: ${DEFAULT_CONFIG.version}`);
   console.info('='.repeat(60));
 
@@ -31,7 +33,9 @@ async function main(): Promise<void> {
 
   // ── 2. Register configured agents ───────────────────────────────────────
 
-  if (DEFAULT_CONFIG.loadSeedData) {
+  if (pairingMode) {
+    console.info('[startup] Pairing-only mode: demo data and autonomous skills disabled.');
+  } else if (DEFAULT_CONFIG.loadSeedData) {
     console.info('[startup] Loading seed data...');
     state.bulkLoad({
       agents: SEED_AGENTS,
@@ -79,7 +83,17 @@ async function main(): Promise<void> {
 
   // Print dev token for easy curl testing
   const devToken = gateway.tokenManager.getDefaultDevToken();
-  if (devToken) {
+  if (pairingMode) {
+    const publicUrl = process.env['OPENCLAW_PUBLIC_URL']?.trim() || `http://localhost:${DEFAULT_CONFIG.port}`;
+    const pairPageUrl = `http://127.0.0.1:${DEFAULT_CONFIG.port}/pair`;
+    console.info('');
+    console.info('Pair your phone:');
+    console.info('  1. In OpenClaw Console, tap Add Gateway');
+    console.info('  2. Tap Scan QR Code');
+    console.info(`  3. Scan the QR page opened on this Mac: ${pairPageUrl}`);
+    console.info(`  Gateway URL encoded for the phone: ${publicUrl}`);
+    console.info('');
+  } else if (devToken) {
     console.info('');
     console.info('Quick-start:');
     console.info(`  curl -H "Authorization: Bearer ${devToken}" http://localhost:${DEFAULT_CONFIG.port}/api/health`);
@@ -98,6 +112,9 @@ async function main(): Promise<void> {
   // ── 5. Register and start skills ────────────────────────────────────────
 
   const enabledSkills = new Set(DEFAULT_CONFIG.enabledSkills);
+  if (enabledSkills.size === 0) {
+    console.info('[startup] No autonomous skills enabled.');
+  }
 
   // --- CI Monitor ---
   if (enabledSkills.has('ci-monitor')) {
@@ -169,12 +186,14 @@ async function main(): Promise<void> {
   }
 
   // --- Daily Brief Agent ---
-  const dailyBrief = new DailyBriefSkill(state, {
-    agentId: AGENT_IDS.DEPLOY_MANAGER, // Reuse deploy manager as the executive assistant for now
-    agentName: 'Executive Assistant',
-    intervalMs: 86400000 // 24 hours
-  });
-  void dailyBrief.start();
+  if (!pairingMode && enabledSkills.has('daily-brief')) {
+    const dailyBrief = new DailyBriefSkill(state, {
+      agentId: AGENT_IDS.DEPLOY_MANAGER, // Reuse deploy manager as the executive assistant for now
+      agentName: 'Executive Assistant',
+      intervalMs: 86400000 // 24 hours
+    });
+    void dailyBrief.start();
+  }
 
   // --- Simulated Bridge Sessions (Demo) ---
   if (DEFAULT_CONFIG.simulateBridges) {
@@ -206,7 +225,7 @@ async function main(): Promise<void> {
     });
   }
 
-  console.info('[startup] All skills initialized. Gateway ready.');
+  console.info(pairingMode ? '[startup] Pairing gateway ready.' : '[startup] All skills initialized. Gateway ready.');
   console.info('');
 
   // ── 6. Graceful shutdown ─────────────────────────────────────────────────

--- a/openclaw-skills/tests/pairing.test.ts
+++ b/openclaw-skills/tests/pairing.test.ts
@@ -82,6 +82,12 @@ describe('gateway pairing', () => {
     expect(inferGatewayBaseUrl(mockReq(), DEFAULT_CONFIG)).toBe('https://gateway.example.com');
   });
 
+  test('ignores malformed OPENCLAW_PUBLIC_URL values', () => {
+    process.env['OPENCLAW_PUBLIC_URL'] = 'http://:18789';
+
+    expect(inferGatewayBaseUrl(mockReq(), DEFAULT_CONFIG)).toBe('http://192.168.1.5:18789');
+  });
+
   test('builds stable mobile pairing payload and URI', () => {
     const { manager, filePath } = makeTokenManager();
     process.env['OPENCLAW_GATEWAY_NAME'] = 'Mac Mini';


### PR DESCRIPTION
## Summary
- add a one-command quiet pairing mode for the gateway via `npm run pair`
- auto-detect the Mac LAN URL and open the local QR page
- disable demo seed data, simulated bridge sessions, and autonomous skills in pairing mode
- ignore malformed `OPENCLAW_PUBLIC_URL` values so pairing links do not become `http://:18789`

## Verification
- `npm run build` in `openclaw-skills`
- `npm test -- --runInBand` in `openclaw-skills`: 15 suites, 133 tests
- pre-push hook: Android debug build passed, skills tests passed
- smoke: `PORT=19879 OPENCLAW_PAIRING_OPEN_BROWSER=false npm run pair` produced a LAN pairing URL and SVG QR page without demo/autonomous agent logs