### PR TITLE
ci: align develop ruleset required checks

### DIFF
--- a/.github/branch-protection.yml
+++ b/.github/branch-protection.yml
@@ -48,6 +48,16 @@ develop:
       - "Architecture Lint (Swift)"
       - "Android Emulator + Maestro Tests"
       - "iOS Simulator Tests"
+      - "Android Build Check"
+      - "Android Agent Guardrails"
+      - "App Icon Parity"
+      - "Brand Parity"
+      - "Release Contract"
+      - "Secrets Scan"
+      - "Dependency Audit"
+      - "CodeQL Analysis (javascript-typescript)"
+      - "Claude Review"
+      - "reconcile-pr-state"
   enforce_admins: true
   required_pull_request_reviews:
     dismiss_stale_reviews: true

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -67,6 +67,16 @@ branches:
           - "Architecture Lint (Swift)"
           - "Android Emulator + Maestro Tests"
           - "iOS Simulator Tests"
+          - "Android Build Check"
+          - "Android Agent Guardrails"
+          - "App Icon Parity"
+          - "Brand Parity"
+          - "Release Contract"
+          - "Secrets Scan"
+          - "Dependency Audit"
+          - "CodeQL Analysis (javascript-typescript)"
+          - "Claude Review"
+          - "reconcile-pr-state"
       enforce_admins: true
       required_pull_request_reviews:
         required_approving_review_count: 0


### PR DESCRIPTION
## Summary
- align tracked develop branch-protection references with the live GitHub ruleset
- persist the stricter required checks now enforced on develop
- keep iOS Simulator Tests as the required iOS gate instead of the redundant queued iOS Build Check

## Evidence
- YAML parse passed for `.github/branch-protection.yml` and `.github/settings.yml`
- pre-push passed
- Android: `:app:testDebugUnitTest :app:assembleDebug` passed during pre-push
- Skills: 15 suites / 133 tests passed during pre-push
