### PR TITLE
chore: ignore local runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ firebase-debug.log
 
 # Worktrees
 .claude/worktrees/
+
+# Local runtime state and generated operator artifacts
+openclaw-skills/data/
+reports/


### PR DESCRIPTION
## Summary
- Ignore local gateway runtime state under openclaw-skills/data/
- Ignore generated operator reports under reports/

## Verification
- Pre-commit checks passed
- Pre-push verification passed
- Android unit tests + debug build: BUILD SUCCESSFUL
- Skills tests: 15 suites passed, 133 tests passed
- git check-ignore verifies openclaw-skills/data/* and reports/* are ignored