### PR TITLE
fix(android): accept OpenClaw setup code pairing

### DIFF
--- a/android/app/src/main/java/com/openclaw/console/data/model/GatewayPairing.kt
+++ b/android/app/src/main/java/com/openclaw/console/data/model/GatewayPairing.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.Json
 import java.net.URI
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+import java.util.Base64
 
 data class GatewayPairing(
     val name: String,
@@ -23,8 +24,10 @@ data class GatewayPairing(
                 return@runCatching parseJson(raw)
             }
 
+            parseSetupCode(raw)?.let { return@runCatching it }
+
             val uri = URI(raw)
-            if (uri.scheme == "http" || uri.scheme == "https") {
+            if (uri.scheme == "http" || uri.scheme == "https" || uri.scheme == "ws" || uri.scheme == "wss") {
                 return@runCatching parseGatewayUrl(uri)
             }
 
@@ -45,23 +48,45 @@ data class GatewayPairing(
             require(payload.type == "openclaw.gateway.pairing.v1") {
                 "Paste an OpenClaw pairing link or pairing JSON."
             }
-            return build(payload.name, payload.baseUrl, payload.token)
+            return build(payload.name, payload.baseUrl ?: payload.url, payload.bootstrapToken ?: payload.token)
+        }
+
+        private fun parseSetupCode(raw: String): GatewayPairing? {
+            val decoded = decodeSetupCode(raw) ?: return null
+            val payload = json.decodeFromString<SetupCodePayload>(decoded)
+            return build(
+                name = payload.name,
+                baseUrl = payload.baseUrl ?: payload.url,
+                token = payload.bootstrapToken ?: payload.token
+            )
         }
 
         private fun parseGatewayUrl(uri: URI): GatewayPairing {
             val query = parseQuery(uri.rawQuery.orEmpty())
-            val token = query["token"] ?: query["tkn"]
+            val token = query["bootstrapToken"] ?: query["token"] ?: query["tkn"]
             val path = uri.rawPath.orEmpty().removeSuffix("/api/health").removeSuffix("/")
             val port = if (uri.port == -1) "" else ":${uri.port}"
-            val baseUrl = "${uri.scheme}://${uri.host}$port$path"
+            val scheme = when (uri.scheme) {
+                "wss" -> "https"
+                "ws" -> "http"
+                else -> uri.scheme
+            }
+            val baseUrl = "$scheme://${uri.host}$port$path"
             val name = uri.host?.takeIf { it.isNotBlank() }?.let { "OpenClaw $it" }
 
             return build(name = name, baseUrl = baseUrl, token = token)
         }
 
+        private fun decodeSetupCode(raw: String): String? {
+            if (raw.any { it.isWhitespace() }) return null
+            return runCatching {
+                String(Base64.getUrlDecoder().decode(raw), StandardCharsets.UTF_8)
+            }.getOrNull()?.takeIf { it.trimStart().startsWith("{") }
+        }
+
         private fun build(name: String?, baseUrl: String?, token: String?): GatewayPairing {
             val cleanedName = name.orEmpty().trim().ifBlank { "OpenClaw Gateway" }
-            val cleanedBaseUrl = baseUrl.orEmpty().trim().trimEnd('/')
+            val cleanedBaseUrl = baseUrl.orEmpty().trim().trimEnd('/').normalizeGatewayUrl()
             val cleanedToken = token.orEmpty().trim()
 
             require(cleanedBaseUrl.isNotBlank()) { "Pairing code is missing base_url." }
@@ -92,6 +117,12 @@ data class GatewayPairing(
 
         private fun decode(value: String): String =
             URLDecoder.decode(value, StandardCharsets.UTF_8.name())
+
+        private fun String.normalizeGatewayUrl(): String = when {
+            startsWith("wss://") -> replaceFirst("wss://", "https://")
+            startsWith("ws://") -> replaceFirst("ws://", "http://")
+            else -> this
+        }
     }
 }
 
@@ -100,5 +131,16 @@ private data class PairingJsonPayload(
     val type: String,
     val name: String? = null,
     @SerialName("base_url") val baseUrl: String? = null,
-    val token: String? = null
+    val url: String? = null,
+    val token: String? = null,
+    val bootstrapToken: String? = null
+)
+
+@Serializable
+private data class SetupCodePayload(
+    val name: String? = null,
+    @SerialName("base_url") val baseUrl: String? = null,
+    val url: String? = null,
+    val token: String? = null,
+    val bootstrapToken: String? = null
 )

--- a/android/app/src/test/java/com/openclaw/console/data/model/GatewayPairingTest.kt
+++ b/android/app/src/test/java/com/openclaw/console/data/model/GatewayPairingTest.kt
@@ -29,13 +29,35 @@ class GatewayPairingTest {
     }
 
     @Test
+    fun `parses cli setup code with bootstrap token`() {
+        val raw = "eyJ1cmwiOiJ3c3M6Ly9pZ29ycy1tYWMtbWluaS50YWlsMTJhYTMzLnRzLm5ldCIsImJvb3RzdHJhcFRva2VuIjoic2V0dXAtdG9rZW4ifQ"
+
+        val pairing = GatewayPairing.parse(raw).getOrThrow()
+
+        assertEquals("OpenClaw Gateway", pairing.name)
+        assertEquals("https://igors-mac-mini.tail12aa33.ts.net", pairing.baseUrl)
+        assertEquals("setup-token", pairing.token)
+    }
+
+    @Test
+    fun `parses wss gateway url with bootstrap token`() {
+        val raw = "wss://igors-mac-mini.tail12aa33.ts.net?bootstrapToken=setup-token"
+
+        val pairing = GatewayPairing.parse(raw).getOrThrow()
+
+        assertEquals("OpenClaw igors-mac-mini.tail12aa33.ts.net", pairing.name)
+        assertEquals("https://igors-mac-mini.tail12aa33.ts.net", pairing.baseUrl)
+        assertEquals("setup-token", pairing.token)
+    }
+
+    @Test
     fun `parses pairing json`() {
         val raw = """
             {
               "type": "openclaw.gateway.pairing.v1",
               "name": "Production",
-              "base_url": "https://gateway.example.com/",
-              "token": "token-value"
+              "url": "wss://gateway.example.com/",
+              "bootstrapToken": "token-value"
             }
         """.trimIndent()
 


### PR DESCRIPTION
## Summary
- Accept OpenClaw CLI setup codes in Android gateway pairing
- Support bootstrapToken, url/base_url payloads, and ws/wss URL normalization
- Add parser coverage for Tailscale-style setup codes and wss gateway URLs

## Verification
- python3 scripts/check_android_cli.py
- python3 scripts/sync_app_icons.py --check
- ./scripts/check-brand-parity.sh
- cd android && ./gradlew :app:testDebugUnitTest --tests 'com.openclaw.console.data.model.GatewayPairingTest' --no-daemon
- cd android && ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:lintDebug --no-daemon
- pre-push verification: release contract, Android guardrails, Android debug build/unit tests, skills tests (15 suites, 133 tests)

## Deployment
Not deployed yet. Internal Firebase distribution runs after CI succeeds on develop/main, or via manual workflow dispatch.