### PR TITLE
fix(android): clarify gateway pairing setup

### DIFF
--- a/android/app/src/main/java/com/openclaw/console/data/model/GatewayPairing.kt
+++ b/android/app/src/main/java/com/openclaw/console/data/model/GatewayPairing.kt
@@ -15,10 +15,11 @@ data class GatewayPairing(
 ) {
     companion object {
         private val json = Json { ignoreUnknownKeys = true }
+        private const val PAIRING_FORMAT_MESSAGE = "Paste an OpenClaw setup code, pairing link, or pairing JSON."
 
         fun parse(rawValue: String): Result<GatewayPairing> = runCatching {
             val raw = rawValue.trim()
-            require(raw.isNotEmpty()) { "Paste an OpenClaw pairing link or pairing JSON." }
+            require(raw.isNotEmpty()) { PAIRING_FORMAT_MESSAGE }
 
             if (raw.startsWith("{")) {
                 return@runCatching parseJson(raw)
@@ -32,21 +33,21 @@ data class GatewayPairing(
             }
 
             require(uri.scheme == "openclaw" && uri.host == "pair") {
-                "Paste an OpenClaw pairing link or pairing JSON."
+                PAIRING_FORMAT_MESSAGE
             }
             val query = parseQuery(uri.rawQuery.orEmpty())
 
             build(
                 name = query["name"],
                 baseUrl = query["base_url"] ?: query["baseUrl"] ?: query["baseURL"],
-                token = query["token"] ?: query["tkn"]
+                token = query["bootstrapToken"] ?: query["token"] ?: query["tkn"]
             )
         }
 
         private fun parseJson(raw: String): GatewayPairing {
             val payload = json.decodeFromString<PairingJsonPayload>(raw)
             require(payload.type == "openclaw.gateway.pairing.v1") {
-                "Paste an OpenClaw pairing link or pairing JSON."
+                PAIRING_FORMAT_MESSAGE
             }
             return build(payload.name, payload.baseUrl ?: payload.url, payload.bootstrapToken ?: payload.token)
         }

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/settings/AddGatewayScreen.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/settings/AddGatewayScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -37,6 +38,7 @@ fun AddGatewayScreen(
 ) {
     val gatewayRepo = appViewModel.gatewayRepository
     val uiState by viewModel.addGatewayUiState.collectAsStateWithLifecycle()
+    val clipboardManager = LocalClipboardManager.current
     val focusManager = LocalFocusManager.current
     var tokenVisible by remember { mutableStateOf(false) }
 
@@ -99,7 +101,7 @@ fun AddGatewayScreen(
                             tint = MaterialTheme.colorScheme.onPrimaryContainer
                         )
                         Text(
-                            text = "Pair by QR or Link",
+                            text = "Pair by QR or Code",
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onPrimaryContainer
                         )
@@ -123,10 +125,10 @@ fun AddGatewayScreen(
                     OutlinedTextField(
                         value = uiState.pairingCode,
                         onValueChange = viewModel::onPairingCodeChange,
-                        label = { Text("Pairing link") },
-                        placeholder = { Text("openclaw://pair?...") },
+                        label = { Text("Setup code, link, or JSON") },
+                        placeholder = { Text("Paste the code from OpenClaw") },
                         modifier = Modifier.fillMaxWidth(),
-                        leadingIcon = { Icon(Icons.Default.Link, contentDescription = null) },
+                        leadingIcon = { Icon(Icons.Default.Key, contentDescription = null) },
                         minLines = 1,
                         maxLines = 3,
                         keyboardOptions = KeyboardOptions(
@@ -138,15 +140,61 @@ fun AddGatewayScreen(
                         )
                     )
 
-                    OutlinedButton(
-                        onClick = viewModel::applyPairingCode,
-                        enabled = uiState.pairingCode.isNotBlank(),
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Icon(Icons.Default.Link, contentDescription = null)
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text("Use Pairing Link")
+                    uiState.pairingImportMessage?.let { message ->
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            shape = MaterialTheme.shapes.small
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(10.dp),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    Icons.Default.CheckCircle,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Text(
+                                    text = message,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
+                        }
                     }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        OutlinedButton(
+                            onClick = {
+                                clipboardManager.getText()?.text
+                                    ?.takeIf { it.isNotBlank() }
+                                    ?.let(viewModel::onPairingCodeChange)
+                            },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Icon(Icons.Default.ContentPaste, contentDescription = null)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text("Paste")
+                        }
+
+                        Button(
+                            onClick = viewModel::applyPairingCode,
+                            enabled = uiState.pairingCode.isNotBlank(),
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Icon(Icons.Default.Key, contentDescription = null)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text("Use Code")
+                        }
+                    }
+
                 }
             }
 

--- a/android/app/src/main/java/com/openclaw/console/ui/screens/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/openclaw/console/ui/screens/settings/SettingsViewModel.kt
@@ -24,6 +24,7 @@ data class AddGatewayUiState(
     val baseUrl: String = "",
     val token: String = "",
     val pairingCode: String = "",
+    val pairingImportMessage: String? = null,
     val isLoading: Boolean = false,
     val testResult: TestResult? = null,
     val error: String? = null,
@@ -86,6 +87,7 @@ class SettingsViewModel : ViewModel() {
     fun onPairingCodeChange(pairingCode: String) {
         _addGatewayUiState.value = _addGatewayUiState.value.copy(
             pairingCode = pairingCode,
+            pairingImportMessage = null,
             error = null,
             testResult = null
         )
@@ -100,6 +102,7 @@ class SettingsViewModel : ViewModel() {
                     baseUrl = pairing.baseUrl,
                     token = pairing.token,
                     error = null,
+                    pairingImportMessage = "Setup code accepted. Review the gateway details, then test and save.",
                     showHttpWarning = pairing.baseUrl.startsWith("http://"),
                     testResult = null
                 )
@@ -117,6 +120,7 @@ class SettingsViewModel : ViewModel() {
                     baseUrl = pairing.baseUrl,
                     token = pairing.token,
                     pairingCode = rawValue,
+                    pairingImportMessage = "QR code accepted. Review the gateway details, then test and save.",
                     testResult = null,
                     error = null,
                     showHttpWarning = pairing.baseUrl.startsWith("http://")
@@ -179,6 +183,7 @@ class SettingsViewModel : ViewModel() {
                     baseUrl = pairing.baseUrl,
                     token = pairing.token,
                     pairingCode = rawValue,
+                    pairingImportMessage = "Pairing accepted. Testing the gateway connection.",
                     showHttpWarning = pairing.baseUrl.startsWith("http://")
                 )
                 testAndSave(onSuccess)

--- a/android/app/src/test/java/com/openclaw/console/data/model/GatewayPairingTest.kt
+++ b/android/app/src/test/java/com/openclaw/console/data/model/GatewayPairingTest.kt
@@ -8,7 +8,7 @@ class GatewayPairingTest {
 
     @Test
     fun `parses openclaw pairing link`() {
-        val raw = "openclaw://pair?name=Mac%20Mini&base_url=http%3A%2F%2F192.168.1.5%3A18789&token=abc123"
+        val raw = "openclaw://pair?name=Mac%20Mini&base_url=http%3A%2F%2F192.168.1.5%3A18789&bootstrapToken=abc123"
 
         val pairing = GatewayPairing.parse(raw).getOrThrow()
 

--- a/android/app/src/test/java/com/openclaw/console/ui/screens/settings/SettingsViewModelTest.kt
+++ b/android/app/src/test/java/com/openclaw/console/ui/screens/settings/SettingsViewModelTest.kt
@@ -1,0 +1,42 @@
+package com.openclaw.console.ui.screens.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SettingsViewModelTest {
+
+    @Test
+    fun `scanned setup code fills gateway fields and shows accepted message`() {
+        val viewModel = SettingsViewModel()
+        val setupCode =
+            "eyJ1cmwiOiJ3c3M6Ly9pZ29ycy1tYWMtbWluaS50YWlsMTJhYTMzLnRzLm5ldCIsImJvb3RzdHJhcFRva2VuIjoic2V0dXAtdG9rZW4ifQ"
+
+        viewModel.applyScannedPairingCode(setupCode)
+
+        val state = viewModel.addGatewayUiState.value
+        assertEquals("OpenClaw Gateway", state.name)
+        assertEquals("https://igors-mac-mini.tail12aa33.ts.net", state.baseUrl)
+        assertEquals("setup-token", state.token)
+        assertEquals(setupCode, state.pairingCode)
+        assertEquals("QR code accepted. Review the gateway details, then test and save.", state.pairingImportMessage)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `manual setup code fills gateway fields and shows accepted message`() {
+        val viewModel = SettingsViewModel()
+        val setupCode =
+            "eyJ1cmwiOiJ3c3M6Ly9pZ29ycy1tYWMtbWluaS50YWlsMTJhYTMzLnRzLm5ldCIsImJvb3RzdHJhcFRva2VuIjoic2V0dXAtdG9rZW4ifQ"
+
+        viewModel.onPairingCodeChange(setupCode)
+        viewModel.applyPairingCode()
+
+        val state = viewModel.addGatewayUiState.value
+        assertEquals("OpenClaw Gateway", state.name)
+        assertEquals("https://igors-mac-mini.tail12aa33.ts.net", state.baseUrl)
+        assertEquals("setup-token", state.token)
+        assertEquals("Setup code accepted. Review the gateway details, then test and save.", state.pairingImportMessage)
+        assertNull(state.error)
+    }
+}


### PR DESCRIPTION
## Summary
- clarify Android add-gateway copy to accept setup codes, links, and JSON
- add one-tap clipboard paste and accepted-state feedback after QR/manual pairing parse
- accept bootstrapToken in openclaw://pair links and add ViewModel coverage for setup-code import

## Verification
- python3 scripts/check_android_cli.py
- python3 scripts/sync_app_icons.py --check
- ./scripts/check-brand-parity.sh
- cd android && ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:lintDebug --no-daemon
- git push pre-push verification: release contract, Android guardrails, Android debug build/unit tests, skills tests (15 suites, 133 tests)