### PR TITLE
fix(ci): scope manual Security Pipeline CodeQL scans

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,19 @@ on:
   schedule:
     - cron: "0 0 * * *" # Daily at midnight UTC
   workflow_dispatch:
+    inputs:
+      full_scan:
+        description: "Run all CodeQL languages instead of scoping to changed files"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      base_branch:
+        description: "Base branch for scoped manual runs"
+        required: false
+        default: "develop"
   push:
     branches: [main, develop]
     paths:
@@ -43,7 +56,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.full_scan || 'false' }}" == "true" ]]; then
             {
               echo "android_changed=true"
               echo "ios_changed=true"
@@ -57,6 +70,10 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
             git diff --name-only "origin/${{ github.base_ref }}"...HEAD > changed-files.txt
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            BASE_BRANCH="${{ inputs.base_branch || 'develop' }}"
+            git fetch --no-tags --depth=1 origin "$BASE_BRANCH"
+            git diff --name-only "origin/${BASE_BRANCH}"...HEAD > changed-files.txt
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
             git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" > changed-files.txt
           else


### PR DESCRIPTION
## Summary
- Scope workflow_dispatch Security Pipeline CodeQL languages from changed files by default
- Keep scheduled scans and explicit full_scan=true manual runs as full all-language scans
- Add base_branch input for scoped manual runs

## Verification
- Parsed .github/workflows/security.yml with PyYAML
- git diff --check
- python3 scripts/check_agent_workflow_settings.py
- python3 scripts/validate_release_contract.py --platform both
- pre-push verification passed: release contract, Android guardrails, flaky guardrails, agent workflow settings, architecture context guardrails, mobile coverage, Android debug build/unit tests, skills tests (133 passed)