### PR TITLE
fix: resolve Sentry initialization crash on app startup

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,6 +49,9 @@
             </intent-filter>
         </receiver>
 
+        <!-- Disable Sentry auto-initialization to prevent crashes when DSN is not configured -->
+        <meta-data android:name="io.sentry.auto-init" android:value="false" />
+
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/openclaw/console/OpenClawApplication.kt
+++ b/android/app/src/main/java/com/openclaw/console/OpenClawApplication.kt
@@ -3,6 +3,7 @@ package com.openclaw.console
 import android.app.Application
 import android.util.Log
 import com.openclaw.console.service.subscription.SubscriptionService
+import io.sentry.android.core.SentryAndroid
 
 /**
  * OpenClaw Console Application class
@@ -19,6 +20,17 @@ class OpenClawApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         Log.i(TAG, "OpenClaw Console starting...")
+
+        // Initialize Sentry for error tracking, but only if DSN is configured
+        val sentryDsn = BuildConfig.SENTRY_DSN
+        if (sentryDsn.isNotBlank()) {
+            SentryAndroid.init(this) { options ->
+                options.dsn = sentryDsn
+            }
+            Log.i(TAG, "Sentry error tracking initialized")
+        } else {
+            Log.i(TAG, "Sentry error tracking disabled (no DSN configured)")
+        }
 
         // Configure RevenueCat. The key is baked in via BuildConfig at build time
         // (set in CI from the REVENUECAT_PUBLIC_KEY secret). When the key is blank


### PR DESCRIPTION
App crashed on startup due to Sentry auto-initialization when DSN not configured. This fix disables Sentry auto-init via manifest meta-data and adds manual Sentry initialization only when SENTRY_DSN is configured.